### PR TITLE
hook up CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+on: push
+name: Run tests
+jobs:
+  tests:
+    name: tests
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    container:
+      image: georust/geo-ci
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - run: script/download-test-data.sh
+      - run: cargo test
+      - run: cargo test --features full_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,4 +12,4 @@ jobs:
         uses: actions/checkout@v2
       - run: script/download-test-data.sh
       - run: cargo test
-      - run: cargo test --features full_test
+      - run: cargo test --features test_full

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@
 __pycache__
 
 # Folder for holding potentially large test data files.
-/test_fixtures/test-data-unzipped
+/test_fixtures/test_data_unzipped

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,13 @@ documentation = "https://docs.rs/geographiclib-rs"
 readme = "README.md"
 
 [features]
-full_test = []
+# Run tests against Karney's GeodTest.dat test cases. 
+# You must run script/download-test-data.sh before using this feature
+test_full = []
+
+# Run tests against Karney's abridged GeodTest-short.dat test cases. 
+# You must run script/download-test-data.sh before using this feature
+test_short = []
 
 [dependencies]
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["gis", "geo", "geography", "geospatial"]
 documentation = "https://docs.rs/geographiclib-rs"
 readme = "README.md"
 
+[features]
+full_test = []
+
 [dependencies]
 lazy_static = "1.4.0"
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,3 @@
+status = [
+    "tests"
+]

--- a/script/download-test-data.sh
+++ b/script/download-test-data.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -ex
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+OUTPUT_DIR="${REPO_ROOT}/test_fixtures/test_data_unzipped"
+
+mkdir -p "${OUTPUT_DIR}"
+
+curl -L https://sourceforge.net/projects/geographiclib/files/testdata/GeodTest.dat.gz | gunzip > "${OUTPUT_DIR}/GeodTest.dat"
+curl -L https://sourceforge.net/projects/geographiclib/files/testdata/GeodTest-short.dat.gz | gunzip > "${OUTPUT_DIR}/GeodTest-short.dat"
+

--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -2080,14 +2080,16 @@ mod tests {
     // These tests are flagged as "ignore" because they're slow and not self-contained
     // (since they need to read data files), so they only run if specifically requested.
 
-    fn geodtest_basic<T>(f: T)
+    static FULL_TEST_PATH: &str = "test_fixtures/test_data_unzipped/GeodTest.dat";
+    static SHORT_TEST_PATH: &str = "test_fixtures/test_data_unzipped/GeodTest-short.dat";
+
+    fn geodtest_basic<T>(path: &str, f: T)
     where
         T: Fn(usize, &(f64, f64, f64, f64, f64, f64, f64, f64, f64, f64)),
     {
         let dir_base = std::env::current_dir().expect("Failed to determine current directory");
         let path_base = dir_base.as_path();
-        let pathbuf =
-            std::path::Path::new(path_base).join("test_fixtures/test_data_unzipped/GeodTest.dat");
+        let pathbuf = std::path::Path::new(path_base).join(path);
         let path = pathbuf.as_path();
         let file = match std::fs::File::open(path) {
             Ok(val) => val,
@@ -2095,7 +2097,7 @@ mod tests {
                 let path_str = path
                     .to_str()
                     .expect("Failed to convert GeodTest path to string during error reporting");
-                panic!("Failed to open GeodTest.dat file. It may need to be downloaded and unzipped to: {}\nFor details see https://geographiclib.sourceforge.io/html/geodesic.html#testgeod", path_str)
+                panic!("Failed to open test input file. Run `script/download-test-data.sh` to download test input to: {}\nFor details see https://geographiclib.sourceforge.io/html/geodesic.html#testgeod", path_str)
             }
         };
         let reader = std::io::BufReader::new(file);
@@ -2121,10 +2123,17 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Slow. Requires external file.
     fn test_geodtest_geodesic_direct12() {
         let g = std::sync::Arc::new(std::sync::Mutex::new(Geodesic::wgs84()));
+
+        let input = if cfg!(feature = "full_test") {
+            FULL_TEST_PATH
+        } else {
+            SHORT_TEST_PATH
+        };
+
         geodtest_basic(
+            input,
             |_line_num, &(lat1, lon1, azi1, lat2, lon2, azi2, s12, a12, m12, S12)| {
                 let g = g.lock().unwrap();
                 let (lat2_out, lon2_out, azi2_out, m12_out, _M12_out, _M21_out, S12_out, a12_out) =
@@ -2140,10 +2149,17 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Slow. Requires external file.
     fn test_geodtest_geodesic_direct21() {
         let g = std::sync::Arc::new(std::sync::Mutex::new(Geodesic::wgs84()));
+
+        let input = if cfg!(feature = "full_test") {
+            FULL_TEST_PATH
+        } else {
+            SHORT_TEST_PATH
+        };
+
         geodtest_basic(
+            input,
             |_line_num, &(lat1, lon1, azi1, lat2, lon2, azi2, s12, a12, m12, S12)| {
                 let g = g.lock().unwrap();
                 // Reverse some values for 2->1 instead of 1->2
@@ -2162,10 +2178,17 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Slow. Requires external file.
     fn test_geodtest_geodesic_inverse12() {
         let g = std::sync::Arc::new(std::sync::Mutex::new(Geodesic::wgs84()));
+
+        let input = if cfg!(feature = "full_test") {
+            FULL_TEST_PATH
+        } else {
+            SHORT_TEST_PATH
+        };
+
         geodtest_basic(
+            input,
             |_line_num, &(lat1, lon1, azi1, lat2, lon2, azi2, s12, a12, m12, S12)| {
                 let g = g.lock().unwrap();
                 let (s12_out, azi1_out, azi2_out, m12_out, _M12_out, _M21_out, S12_out, a12_out) =

--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -2087,7 +2087,7 @@ mod tests {
         let dir_base = std::env::current_dir().expect("Failed to determine current directory");
         let path_base = dir_base.as_path();
         let pathbuf =
-            std::path::Path::new(path_base).join("test_fixtures/test-data-unzipped/GeodTest.dat");
+            std::path::Path::new(path_base).join("test_fixtures/test_data_unzipped/GeodTest.dat");
         let path = pathbuf.as_path();
         let file = match std::fs::File::open(path) {
             Ok(val) => val,

--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -2082,6 +2082,16 @@ mod tests {
 
     static FULL_TEST_PATH: &str = "test_fixtures/test_data_unzipped/GeodTest.dat";
     static SHORT_TEST_PATH: &str = "test_fixtures/test_data_unzipped/GeodTest-short.dat";
+    static BUILTIN_TEST_PATH: &str = "test_fixtures/GeodTest-100.dat";
+    fn test_input_path() -> &'static str {
+        if cfg!(feature = "test_full") {
+            FULL_TEST_PATH
+        } else if cfg!(feature = "test_short") {
+            SHORT_TEST_PATH
+        } else {
+            BUILTIN_TEST_PATH
+        }
+    }
 
     fn geodtest_basic<T>(path: &str, f: T)
     where
@@ -2126,14 +2136,8 @@ mod tests {
     fn test_geodtest_geodesic_direct12() {
         let g = std::sync::Arc::new(std::sync::Mutex::new(Geodesic::wgs84()));
 
-        let input = if cfg!(feature = "full_test") {
-            FULL_TEST_PATH
-        } else {
-            SHORT_TEST_PATH
-        };
-
         geodtest_basic(
-            input,
+            test_input_path(),
             |_line_num, &(lat1, lon1, azi1, lat2, lon2, azi2, s12, a12, m12, S12)| {
                 let g = g.lock().unwrap();
                 let (lat2_out, lon2_out, azi2_out, m12_out, _M12_out, _M21_out, S12_out, a12_out) =
@@ -2152,14 +2156,8 @@ mod tests {
     fn test_geodtest_geodesic_direct21() {
         let g = std::sync::Arc::new(std::sync::Mutex::new(Geodesic::wgs84()));
 
-        let input = if cfg!(feature = "full_test") {
-            FULL_TEST_PATH
-        } else {
-            SHORT_TEST_PATH
-        };
-
         geodtest_basic(
-            input,
+            test_input_path(),
             |_line_num, &(lat1, lon1, azi1, lat2, lon2, azi2, s12, a12, m12, S12)| {
                 let g = g.lock().unwrap();
                 // Reverse some values for 2->1 instead of 1->2
@@ -2181,14 +2179,8 @@ mod tests {
     fn test_geodtest_geodesic_inverse12() {
         let g = std::sync::Arc::new(std::sync::Mutex::new(Geodesic::wgs84()));
 
-        let input = if cfg!(feature = "full_test") {
-            FULL_TEST_PATH
-        } else {
-            SHORT_TEST_PATH
-        };
-
         geodtest_basic(
-            input,
+            test_input_path(),
             |_line_num, &(lat1, lon1, azi1, lat2, lon2, azi2, s12, a12, m12, S12)| {
                 let g = g.lock().unwrap();
                 let (s12_out, azi1_out, azi2_out, m12_out, _M12_out, _M21_out, S12_out, a12_out) =


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Finishes #13 by hooking up CI.

By default `cargo test` will run against the short data set. `cargo test --features full_test` will run agains the long one.

CI will run full_test (`full_test` is maybe a bit too slow to run all the time for interactive development feedback, but it's not too long for CI).

