### PR TITLE
fix #26: geodsolve76. bug in test itself

### DIFF
--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -2123,15 +2123,14 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Fails existing behavior.
     fn test_std_geodesic_geodsolve2() {
         // Check fix for antipodal prolate bug found 2010-09-04
         let geod = Geodesic::new(6.4e6, -1f64/150.0);
-        let (azi1, azi2, s12) = geod.inverse(0.07476, 0.0, -0.07476, 180.0);
+        let (s12, azi1, azi2, _a12) = geod.inverse(0.07476, 0.0, -0.07476, 180.0);
         assert_approx_eq!(azi1, 90.00078, 0.5e-5);
         assert_approx_eq!(azi2, 90.00078, 0.5e-5);
         assert_approx_eq!(s12, 20106193.0, 0.5);
-        let (azi1, azi2, s12) = geod.inverse(0.1, 0.0, -0.1, 180.0);
+        let (s12, azi1, azi2, _a12) = geod.inverse(0.1, 0.0, -0.1, 180.0);
         assert_approx_eq!(azi1, 90.00105, 0.5e-5);
         assert_approx_eq!(azi2, 90.00105, 0.5e-5);
         assert_approx_eq!(s12, 20106193.0, 0.5);
@@ -2469,11 +2468,10 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Fails existing behavior.
     fn test_std_geodesic_geodsolve78() {
         // An example where the NGS calculator fails to converge
         let geod = Geodesic::wgs84();
-        let (azi1, azi2, s12) = 
+        let (s12, azi1, azi2, _a12) = 
             geod.inverse(27.2, 0.0, -27.1, 179.5);
         assert_approx_eq!(azi1,  45.82468716758, 0.5e-11);
         assert_approx_eq!(azi2, 134.22776532670, 0.5e-11);

--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -2457,12 +2457,11 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Fails existing behavior.
     fn test_std_geodesic_geodsolve76() {
         // The distance from Wellington and Salamanca (a classic failure of
         // Vincenty)
         let geod = Geodesic::wgs84();
-        let (azi1, azi2, s12) = 
+        let (s12, azi1, azi2, _a12) = 
             geod.inverse(-(41.0+19.0/60.0), 174.0+49.0/60.0, 40.0+58.0/60.0, -(5.0+30.0/60.0));
         assert_approx_eq!(azi1, 160.39137649664, 0.5e-11);
         assert_approx_eq!(azi2,  19.50042925176, 0.5e-11);


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This one turned out to be a bug in the test itself: I called the wrong inverse variant when I wrote the translation, resulting in comparing distance in meters with angular distance.