### PR TITLE
Fix #22 and #23: geodsolve15 and geodsolve26

### DIFF
--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -99,18 +99,16 @@ impl Geodesic {
         let _ep2 = _e2 / geomath::sq(_f1);
         let _n = f / (2.0 - f);
         let _b = a * _f1;
-        let _c2 = (geomath::sq(a)
-            + geomath::sq(_b)
-                * (if _e2 == 0.0 {
-                    1.0
-                } else {
-                    if _e2 > 0.0 {
-                        _e2.sqrt().atanh()
-                    } else {
-                        (-_e2).sqrt().atanh()
-                    }
-                } / _e2.abs().sqrt()))
-            / 2.0;
+        let _c2 = (geomath::sq(a) + geomath::sq(_b)
+            * (if _e2 == 0.0 {
+                1.0
+            } else {
+                geomath::eatanhe(
+                    1.0,
+                    (if f < 0.0 { -1.0 } else { 1.0 }) * _e2.abs().sqrt()
+                ) / _e2
+            }
+            )) / 2.0;
         let _etol2 = 0.1 * tol2_ / (f.abs().max(0.001) * (1.0 - f / 2.0).min(1.0) / 2.0).sqrt();
 
         let mut _A3x: [f64; GEODESIC_ORDER as usize] = [0.0; GEODESIC_ORDER as usize];
@@ -2219,7 +2217,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Fails existing behavior.
     fn test_std_geodesic_geodsolve15() {
         // Initial implementation of Math::eatanhe was wrong for e^2 < 0.  This
         // checks that this is fixed.
@@ -2261,7 +2258,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Fails existing behavior.
     fn test_std_geodesic_geodsolve26() {
         // Check 0/0 problem with area calculation on sphere 2015-09-08
         let geod = Geodesic::new(6.4e6, 0.0);

--- a/src/geomath.rs
+++ b/src/geomath.rs
@@ -232,6 +232,10 @@ pub fn atan2d(y: f64, x: f64) -> f64 {
     ang
 }
 
+pub fn eatanhe(x: f64, es: f64) -> f64 {
+    if es > 0.0 { es * (es * x).atanh() } else { -es * (es * x).atan() }
+}
+
 // Functions that used to be inside Geodesic
 pub fn sin_cos_series(sinp: bool, sinx: f64, cosx: f64, c: &[f64]) -> f64 {
     let mut k = c.len();


### PR DESCRIPTION
Changed _c2 calculation to match cpp approach, addressing a problem for the case for f <= 0.
It's tempting to drop eatanhe as a separate function, and simplify the arguments passed,
since this is the only place it's used, but I opted to stick closer to Karney's code.
Adds geomath::eatanhe.

Interestingly, the previous approach seemed to faithfully match the approach used in Java and Python, which I think pass these tests. This may suggest some subtle math handling difference between C++/Rust and Java/Python (maybe in atanh?), or that I'm overlooking some other nuance. I'm just taking the alternate Karney approach that works for us, rather than digging any deeper into the underlying cause.

- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

