### PR TITLE
Address #36: geomath::norm

### DIFF
--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -345,9 +345,7 @@ impl Geodesic {
                         } else {
                             1.0 - comg12
                         });
-            let res = geomath::norm(salp2, calp2);
-            salp2 = res.0;
-            calp2 = res.1;
+            geomath::norm(&mut salp2, &mut calp2);
             sig12 = ssig12.atan2(csig12);
         } else if self._n.abs() >= 0.1
             || csig12 >= 0.0
@@ -416,9 +414,7 @@ impl Geodesic {
             }
         }
         if !(salp1 <= 0.0) {
-            let res = geomath::norm(salp1, calp1);
-            salp1 = res.0;
-            calp1 = res.1;
+            geomath::norm(&mut salp1, &mut calp1);
         } else {
             salp1 = 1.0;
             calp1 = 0.0;
@@ -453,9 +449,7 @@ impl Geodesic {
         let somg1 = salp0 * sbet1;
         let mut csig1 = *calp1 * cbet1;
         let comg1 = *calp1 * cbet1;
-        let res = geomath::norm(ssig1, csig1);
-        ssig1 = res.0;
-        csig1 = res.1;
+        geomath::norm(&mut ssig1, &mut csig1);
 
         let salp2 = if cbet2 != cbet1 { salp0 / cbet2 } else { salp1 };
         let calp2 = if cbet2 != cbet1 || sbet2.abs() != -sbet1 {
@@ -474,9 +468,7 @@ impl Geodesic {
         let somg2 = salp0 * sbet2;
         let mut csig2 = calp2 * cbet2;
         let comg2 = calp2 * cbet2;
-        let res = geomath::norm(ssig2, csig2);
-        ssig2 = res.0;
-        csig2 = res.1;
+        geomath::norm(&mut ssig2, &mut csig2);
 
         let sig12 = ((csig1 * ssig2 - ssig1 * csig2).max(0.0)).atan2(csig1 * csig2 + ssig1 * ssig2);
         let somg12 = (comg1 * somg2 - somg1 * comg2).max(0.0);
@@ -595,16 +587,16 @@ impl Geodesic {
         lat1 *= latsign;
         lat2 *= latsign;
 
-        let (mut sbet1, cbet1) = geomath::sincosd(lat1);
+        let (mut sbet1, mut cbet1) = geomath::sincosd(lat1);
         sbet1 *= self._f1;
 
-        let (sbet1, mut cbet1) = geomath::norm(sbet1, cbet1);
+        geomath::norm(&mut sbet1, &mut cbet1);
         cbet1 = cbet1.max(self.tiny_);
 
-        let (mut sbet2, cbet2) = geomath::sincosd(lat2);
+        let (mut sbet2, mut cbet2) = geomath::sincosd(lat2);
         sbet2 *= self._f1;
 
-        let (mut sbet2, mut cbet2) = geomath::norm(sbet2, cbet2);
+        geomath::norm(&mut sbet2, &mut cbet2);
         cbet2 = cbet2.max(self.tiny_);
 
         if cbet1 < -sbet1 {
@@ -781,9 +773,7 @@ impl Geodesic {
                         if nsalp1 > 0.0 && dalp1.abs() < PI {
                             calp1 = calp1 * cdalp1 - salp1 * sdalp1;
                             salp1 = nsalp1;
-                            let res = geomath::norm(salp1, calp1);
-                            salp1 = res.0;
-                            calp1 = res.1;
+                            geomath::norm(&mut salp1, &mut calp1);
                             tripn = v.abs() <= 16.0 * self.tol0_;
                             continue;
                         }
@@ -791,9 +781,7 @@ impl Geodesic {
 
                     salp1 = (salp1a + salp1b) / 2.0;
                     calp1 = (calp1a + calp1b) / 2.0;
-                    let res = geomath::norm(salp1, calp1);
-                    salp1 = res.0;
-                    calp1 = res.1;
+                    geomath::norm(&mut salp1, &mut calp1);
                     tripn = false;
                     tripb = (salp1a - salp1).abs() + (calp1a - calp1) < self.tolb_
                         || (salp1 - salp1b).abs() + (calp1 - calp1b) < self.tolb_;
@@ -841,12 +829,8 @@ impl Geodesic {
                 let k2 = geomath::sq(calp0) * self._ep2;
                 eps = k2 / (2.0 * (1.0 + (1.0 + k2).sqrt()) + k2);
                 let A4 = geomath::sq(self.a) * calp0 * salp0 * self._e2;
-                let res = geomath::norm(ssig1, csig1);
-                ssig1 = res.0;
-                csig1 = res.1;
-                let res = geomath::norm(ssig2, csig2);
-                ssig2 = res.0;
-                csig2 = res.1;
+                geomath::norm(&mut ssig1, &mut csig1);
+                geomath::norm(&mut ssig2, &mut csig2);
                 let mut C4a: [f64; CARR_SIZE] = [0.0; CARR_SIZE];
                 self._C4f(eps, &mut C4a);
                 let B41 = geomath::sin_cos_series(false, ssig1, csig1, &C4a);

--- a/src/geodesicline.rs
+++ b/src/geodesicline.rs
@@ -87,22 +87,22 @@ impl GeodesicLine {
         };
         let lat1 = geomath::lat_fix(lat1);
 
-        let (mut sbet1, cbet1) = geomath::sincosd(geomath::ang_round(lat1));
+        let (mut sbet1, mut cbet1) = geomath::sincosd(geomath::ang_round(lat1));
         sbet1 *= _f1;
-        let (sbet1, mut cbet1) = geomath::norm(sbet1, cbet1);
+        geomath::norm(&mut sbet1, &mut cbet1);
         cbet1 = tiny_.max(cbet1);
         let _dn1 = (1.0 + geod._ep2 * geomath::sq(sbet1)).sqrt();
         let _salp0 = salp1 * cbet1;
         let _calp0 = calp1.hypot(salp1 * sbet1);
-        let _ssig1 = sbet1;
+        let mut _ssig1 = sbet1;
         let _somg1 = _salp0 * sbet1;
-        let _csig1 = if sbet1 != 0.0 || calp1 != 0.0 {
+        let mut _csig1 = if sbet1 != 0.0 || calp1 != 0.0 {
             cbet1 * calp1
         } else {
             1.0
         };
         let _comg1 = _csig1;
-        let (_ssig1, _csig1) = geomath::norm(_ssig1, _csig1);
+        geomath::norm(&mut _ssig1, &mut _csig1);
         let _k2 = geomath::sq(_calp0) * geod._ep2;
         let eps = _k2 / (2.0 * (1.0 + (1.0 + _k2).sqrt()) + _k2);
 

--- a/src/geomath.rs
+++ b/src/geomath.rs
@@ -33,9 +33,10 @@ pub fn cbrt(x: f64) -> f64 {
 }
 
 // Normalize a two-vector
-pub fn norm(x: f64, y: f64) -> (f64, f64) {
-    let r = x.hypot(y);
-    (x / r, y / r)
+pub fn norm(x: &mut f64, y: &mut f64) {
+    let r = x.hypot(*y);
+    *x /= r;
+    *y /= r;
 }
 
 // Error free transformation of a sum


### PR DESCRIPTION
Changed from fn norm(f64, f64) -> (f64, f64) to fn norm(&mut f64, &mut f64), and changed all callers to match.

- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

