### PR TITLE
fix #20 test_arcdirect

### DIFF
--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -1639,7 +1639,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Fails existing behavior.
     fn test_arcdirect() {
         // Corresponds with ArcDirectCheck from Java, or test_arcdirect from Python
         let geod = Geodesic::wgs84();


### PR DESCRIPTION
Short version: At this point, it just needed to be unignored.

Previously affected by some direct bugs that were fixed as part of earlier commits. An earlier draft accidentally used too demanding of a tolerance for some parameters, also fixed in previous commits, but I had forgotten to merge that tolerance update into my test-heavy "establish-baselines" branch. My polyval suspicion turned out to be a red herring related to array comparisons where I had forgotten that the first element is unused and therefore shouldn't be checked.

- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

