### PR TITLE
Adding PolygonArea for calculating the perimeter and area of a polygon on a Geodesic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## unreleased
+
+### New Features
+
+* Added `PolygonArea` to allow calculating perimeter and area of a polygon on a geodesic.
+
+
 ## 0.2.2
 
 This patch release includes only small clippy/lint fixes, and should not

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ### New Features
 
 * Added `PolygonArea` to allow calculating perimeter and area of a polygon on a geodesic.
-
+* Added `accurate` feature (enabled by default) for highly accurate `PolygonArea` calculations.
 
 ## 0.2.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ test_short = []
 
 [dependencies]
 lazy_static = "1.4.0"
+accurate = { version = "0.3", optional = true, default-features = false }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ test_full = []
 # You must run script/download-test-data.sh before using this feature
 test_short = []
 
+default = ["accurate"]
+
 [dependencies]
 lazy_static = "1.4.0"
 accurate = { version = "0.3", optional = true, default-features = false }

--- a/README.md
+++ b/README.md
@@ -51,11 +51,12 @@ pa.add_point(0.0, 1.0);
 pa.add_point(1.0, 1.0);
 pa.add_point(1.0, 0.0);
 
-let (perimeter_m, area_m_squared) = pa.compute();
+let (perimeter_m, area_m_squared, num_points) = pa.compute(false);
 
 use approx::assert_relative_eq;
 assert_relative_eq!(perimeter_m, 443770.91724830196);
 assert_relative_eq!(area_m_squared, 12308778361.469452);
+assert_eq!(num_points, 4);
 ``` 
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -40,6 +40,40 @@ use approx::assert_relative_eq;
 assert_relative_eq!(s12, 9094718.72751138);
 ``` 
 
+```rust
+// Determine the perimeter and area of a polygon.
+use geographiclib_rs::{Geodesic, PolygonArea, Winding};
+
+let g = Geodesic::wgs84();
+let mut pa = PolygonArea::new(&g, Winding::CounterClockwise);
+pa.add_point(0.0, 0.0);
+pa.add_point(0.0, 1.0);
+pa.add_point(1.0, 1.0);
+pa.add_point(1.0, 0.0);
+
+let (perimeter_m, area_m_squared) = pa.compute();
+
+use approx::assert_relative_eq;
+assert_relative_eq!(perimeter_m, 443770.91724830196);
+assert_relative_eq!(area_m_squared, 12308778361.469452);
+``` 
+
+```rust
+// Determine the distance between rovers Pathfinder and Curiosity on Mars
+use geographiclib_rs::{Geodesic, InverseGeodesic};
+
+let mars = Geodesic::new(3396190.0, 1.0 / 169.8944472);
+let pathfinder = (19.26, 326.75);
+let curiosity = (-4.765700445, 137.39820983);
+let distance_m: f64 = mars.inverse(curiosity.0, curiosity.1, pathfinder.0, pathfinder.1);
+
+assert_eq!(distance_m.round(), 9639113.0);
+```
+
+## Features
+
+1. `accurate`: Enabled by default. Use the [`accurate`](https://docs.rs/accurate/latest/accurate/) crate to provide high accuracy polygon areas and perimeters in `PolygonArea`. Can be disabled for better performance or when `PolygonArea` is not being used.
+
 ## Benchmarking
 
 To compare the direct and inverse geodesic calculation against the [geographiclib c bindings](https://github.com/savage13/geographiclib), run:

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -1,1 +1,0 @@
-// If needed, iport accumulator.py here

--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -2720,4 +2720,28 @@ mod tests {
             },
         );
     }
+
+    #[test]
+    fn test_turnaround() {
+        let g = Geodesic::wgs84();
+
+        let start = (0.0, 0.0);
+        let destination = (0.0, 1.0);
+
+        let (distance, azi1, _, _) = g.inverse(start.0, start.1, destination.0, destination.1);
+
+        // Confirm that we've gone due-east
+        assert_eq!(azi1, 90.0);
+
+        // Turn around by adding 180 degrees to the azimuth
+        let turn_around = azi1 + 180.0;
+
+        // Confirm that turn around is due west
+        assert_eq!(turn_around, 270.0);
+
+        // Test that we can turn around and get back to the starting point.
+        let (lat, lon) = g.direct(destination.0, destination.1, turn_around, distance);
+        assert_relative_eq!(lat, start.0, epsilon = 1.0e-3);
+        assert_relative_eq!(lon, start.1, epsilon = 1.0e-3);
+    }
 }

--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -907,6 +907,11 @@ impl Geodesic {
             geodesicline::GeodesicLine::new(self, lat1, lon1, azi1, Some(outmask), None, None);
         line._gen_position(arcmode, s12_a12, outmask)
     }
+
+    /// Get the area of the geodesic in square meters
+    pub fn area(&self) -> f64 {
+        self._c2 * 4.0 * std::f64::consts::PI
+    }
 }
 
 /// Place a second point, given the first point, an azimuth, and a distance.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 //! A subset of [geographiclib](https://geographiclib.sourceforge.io/) implemented in Rust.
 //!
-//! This library is a subset of the [geographiclib](https://geographiclib.sourceforge.io/) library
-//!
 //! # Examples
 //!
 //! ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,39 @@
+//! A subset of [geographiclib](https://geographiclib.sourceforge.io/) implemented in Rust.
+//! 
+//! This library is a subset of the [geographiclib](https://geographiclib.sourceforge.io/) library
+//! 
+//! # Examples
+//! 
+//! ```rust
+//! // Determine the point 10000 km NE of JFK - the "direct" geodesic calculation.
+//! use geographiclib_rs::{Geodesic, DirectGeodesic};
+//! 
+//! let g = Geodesic::wgs84();
+//! let jfk_lat = 40.64;
+//! let jfk_lon = -73.78;
+//! let northeast_azimuth = 45.0;
+//! 
+//! let (lat, lon, az) = g.direct(jfk_lat, jfk_lon, northeast_azimuth, 10e6);
+//! 
+//! use approx::assert_relative_eq;
+//! assert_relative_eq!(lat, 32.621100463725796);
+//! assert_relative_eq!(lon, 49.05248709295982);
+//! assert_relative_eq!(az,  140.4059858768007);
+//! ```
+//! 
+//! ```rust
+//! // Determine the distance between two points - the "inverse" geodesic calculation.
+//! use geographiclib_rs::{Geodesic, InverseGeodesic};
+//! 
+//! let g = Geodesic::wgs84();
+//! let p1 = (34.095925, -118.2884237);
+//! let p2 = (59.4323439, 24.7341649);
+//! let s12: f64 = g.inverse(p1.0, p1.1, p2.0, p2.1);
+//! 
+//! use approx::assert_relative_eq;
+//! assert_relative_eq!(s12, 9094718.72751138);
+//! ``` 
+
 mod geodesic;
 pub use geodesic::{DirectGeodesic, Geodesic, InverseGeodesic};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod geodesicline;
 mod geomath;
 mod polygonarea;
 pub use polygonarea::PolygonArea;
+pub use polygonarea::Winding;
 
 #[macro_use]
 extern crate lazy_static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,11 +43,12 @@
 //! pa.add_point(1.0, 1.0);
 //! pa.add_point(1.0, 0.0);
 //!
-//! let (perimeter_m, area_m_squared) = pa.compute();
+//! let (perimeter_m, area_m_squared, num_points) = pa.compute(false);
 //!
 //! use approx::assert_relative_eq;
 //! assert_relative_eq!(perimeter_m, 443770.91724830196);
 //! assert_relative_eq!(area_m_squared, 12308778361.469452);
+//! assert_eq!(num_points, 4);
 //! ```
 //!
 //! ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,38 +1,72 @@
 //! A subset of [geographiclib](https://geographiclib.sourceforge.io/) implemented in Rust.
-//! 
+//!
 //! This library is a subset of the [geographiclib](https://geographiclib.sourceforge.io/) library
-//! 
+//!
 //! # Examples
-//! 
+//!
 //! ```rust
 //! // Determine the point 10000 km NE of JFK - the "direct" geodesic calculation.
 //! use geographiclib_rs::{Geodesic, DirectGeodesic};
-//! 
+//!
 //! let g = Geodesic::wgs84();
 //! let jfk_lat = 40.64;
 //! let jfk_lon = -73.78;
 //! let northeast_azimuth = 45.0;
-//! 
+//!
 //! let (lat, lon, az) = g.direct(jfk_lat, jfk_lon, northeast_azimuth, 10e6);
-//! 
+//!
 //! use approx::assert_relative_eq;
 //! assert_relative_eq!(lat, 32.621100463725796);
-//! assert_relative_eq!(lon, 49.05248709295982);
+//! assert_relative_eq!(lon, 49.052487092959836);
 //! assert_relative_eq!(az,  140.4059858768007);
 //! ```
-//! 
+//!
 //! ```rust
 //! // Determine the distance between two points - the "inverse" geodesic calculation.
 //! use geographiclib_rs::{Geodesic, InverseGeodesic};
-//! 
+//!
 //! let g = Geodesic::wgs84();
 //! let p1 = (34.095925, -118.2884237);
 //! let p2 = (59.4323439, 24.7341649);
 //! let s12: f64 = g.inverse(p1.0, p1.1, p2.0, p2.1);
-//! 
+//!
 //! use approx::assert_relative_eq;
 //! assert_relative_eq!(s12, 9094718.72751138);
-//! ``` 
+//! ```
+//!
+//! ```rust
+//! // Determine the perimeter and area of a polygon.
+//! use geographiclib_rs::{Geodesic, PolygonArea, Winding};
+//!
+//! let g = Geodesic::wgs84();
+//! let mut pa = PolygonArea::new(&g, Winding::CounterClockwise);
+//! pa.add_point(0.0, 0.0);
+//! pa.add_point(0.0, 1.0);
+//! pa.add_point(1.0, 1.0);
+//! pa.add_point(1.0, 0.0);
+//!
+//! let (perimeter_m, area_m_squared) = pa.compute();
+//!
+//! use approx::assert_relative_eq;
+//! assert_relative_eq!(perimeter_m, 443770.91724830196);
+//! assert_relative_eq!(area_m_squared, 12308778361.469452);
+//! ```
+//!
+//! ```rust
+//! // Determine the distance between rovers Pathfinder and Curiosity on Mars
+//! use geographiclib_rs::{Geodesic, InverseGeodesic};
+//!
+//! let mars = Geodesic::new(3396190.0, 1.0 / 169.8944472);
+//! let pathfinder = (19.26, 326.75);
+//! let curiosity = (-4.765700445, 137.39820983);
+//! let distance_m: f64 = mars.inverse(curiosity.0, curiosity.1, pathfinder.0, pathfinder.1);
+//!
+//! assert_eq!(distance_m.round(), 9639113.0);
+//! ```
+//!
+//! # Features
+//!
+//! 1. `accurate`: Enabled by default. Use the [`accurate`](https://docs.rs/accurate/latest/accurate/) crate to provide high accuracy polygon areas and perimeters in `PolygonArea`. Can be disabled for better performance or when `PolygonArea` is not being used.
 
 mod geodesic;
 pub use geodesic::{DirectGeodesic, Geodesic, InverseGeodesic};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@ pub use geodesiccapability as capability;
 
 mod geodesicline;
 mod geomath;
-pub mod polygonarea;
+mod polygonarea;
+pub use polygonarea::PolygonArea;
 
 #[macro_use]
 extern crate lazy_static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub use geodesiccapability as capability;
 
 mod geodesicline;
 mod geomath;
+pub mod polygonarea;
 
 #[macro_use]
 extern crate lazy_static;

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -4,6 +4,7 @@ use crate::geodesic::DirectGeodesic;
 use crate::geomath::ang_normalize;
 use crate::geomath::ang_diff;
 
+/// Compute the perimeter and area of a polygon on a Geodesic.
 #[derive(Debug, Clone)]
 pub struct PolygonArea<'a> {
     geoid: &'a Geodesic,

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -1,16 +1,30 @@
-use crate::Geodesic;
-use crate::geodesic::InverseGeodesic;
 use crate::geodesic::DirectGeodesic;
-use crate::geomath::ang_normalize;
+use crate::geodesic::InverseGeodesic;
 use crate::geomath::ang_diff;
+use crate::geomath::ang_normalize;
+use crate::Geodesic;
+
+#[cfg(feature = "accurate")]
+use accurate::traits::*;
 
 /// Compute the perimeter and area of a polygon on a Geodesic.
 #[derive(Debug, Clone)]
 pub struct PolygonArea<'a> {
     geoid: &'a Geodesic,
     num: usize,
+
+    #[cfg(not(feature = "accurate"))]
     areasum: f64,
+
+    #[cfg(feature = "accurate")]
+    areasum: accurate::sum::Sum2<f64>,
+
+    #[cfg(not(feature = "accurate"))]
     perimetersum: f64,
+
+    #[cfg(feature = "accurate")]
+    perimetersum: accurate::sum::Sum2<f64>,
+
     crossings: f64,
     initial_lat: f64,
     initial_lon: f64,
@@ -20,20 +34,20 @@ pub struct PolygonArea<'a> {
 
 // Documentation for PolygonArea
 /// PolygonArea can be used to compute the perimeter and area of a polygon on a Geodesic.
-/// 
+///
 /// # Example
 /// ```rust
 /// use geographiclib_rs::Geodesic;
-/// use geographiclib_rs::polygonarea::PolygonArea;
+/// use geographiclib_rs::PolygonArea;
 ///
 /// let g = Geodesic::wgs84();
 /// let mut pa = PolygonArea::new(&g);
-/// 
+///
 /// pa.add_point(0.0, 0.0);
 /// pa.add_point(0.0, 1.0);
 /// pa.add_point(1.0, 1.0);
 /// pa.add_point(1.0, 0.0);
-//// 
+////
 /// let (perimeter, area) = pa.compute();
 ///
 /// use approx::assert_relative_eq;
@@ -41,14 +55,24 @@ pub struct PolygonArea<'a> {
 /// assert_relative_eq!(area, 12308778361.469452);
 /// ```
 impl<'a> PolygonArea<'a> {
-
     /// Create a new PolygonArea using a Geodesic.
     pub fn new(geoid: &'a Geodesic) -> PolygonArea {
         PolygonArea {
             geoid,
             num: 0,
+
+            #[cfg(not(feature = "accurate"))]
             areasum: 0.0,
+
+            #[cfg(feature = "accurate")]
+            areasum: accurate::sum::Sum2::zero(),
+
+            #[cfg(not(feature = "accurate"))]
             perimetersum: 0.0,
+
+            #[cfg(feature = "accurate")]
+            perimetersum: accurate::sum::Sum2::zero(),
+
             crossings: 0.0,
             initial_lat: 0.0,
             initial_lon: 0.0,
@@ -64,7 +88,9 @@ impl<'a> PolygonArea<'a> {
             self.initial_lon = lon;
         } else {
             #[allow(non_snake_case)]
-            let (s12, _azi1, _azi2, _m12, _M12, _M21, S12, _a12) = self.geoid.inverse(self.latest_lat, self.latest_lon, lat, lon);
+            let (s12, _azi1, _azi2, _m12, _M12, _M21, S12, _a12) =
+                self.geoid
+                    .inverse(self.latest_lat, self.latest_lon, lat, lon);
             self.perimetersum += s12;
             self.areasum += S12;
             self.crossings += PolygonArea::transit(self.latest_lon, lon);
@@ -75,7 +101,7 @@ impl<'a> PolygonArea<'a> {
     }
 
     /// Add an adge to the polygon using an azimuth (in degrees) and a distance (in meters). This can only be called after at least one point has been added.
-    /// 
+    ///
     /// # Panics
     /// Panics if no points have been added yet.
     pub fn add_edge(&mut self, azimuth: f64, distance: f64) {
@@ -84,7 +110,9 @@ impl<'a> PolygonArea<'a> {
         }
 
         #[allow(non_snake_case)]
-        let (lat, lon, _azi2, _m12, _M12, _M21, S12, _a12) = self.geoid.direct(self.latest_lat, self.latest_lon, azimuth, distance);
+        let (lat, lon, _azi2, _m12, _M12, _M21, S12, _a12) =
+            self.geoid
+                .direct(self.latest_lat, self.latest_lon, azimuth, distance);
         self.perimetersum += distance;
         self.areasum += S12;
         self.crossings += PolygonArea::transit(self.latest_lon, lon);
@@ -96,14 +124,34 @@ impl<'a> PolygonArea<'a> {
     /// Return perimeter and area of polygon in meters / meters², consuming PolygonArea.
     pub fn compute(mut self) -> (f64, f64) {
         #[allow(non_snake_case)]
-        let (s12, _azi1, _azi2, _m12, _M12, _M21, S12, _a12) = self.geoid.inverse(self.latest_lat, self.latest_lon, self.initial_lat, self.initial_lon);
+        let (s12, _azi1, _azi2, _m12, _M12, _M21, S12, _a12) = self.geoid.inverse(
+            self.latest_lat,
+            self.latest_lon,
+            self.initial_lat,
+            self.initial_lon,
+        );
         self.perimetersum += s12;
         self.areasum += S12;
+
+        let perimetersum;
+        let areasum;
+
+        #[cfg(not(feature = "accurate"))]
+        {
+            perimetersum = self.perimetersum;
+            areasum = self.areasum;
+        }
+        #[cfg(feature = "accurate")]
+        {
+            perimetersum = self.perimetersum.sum();
+            areasum = self.areasum.sum();
+        }
+
         self.crossings += PolygonArea::transit(self.latest_lon, self.initial_lon);
 
         // TODO: Properly take into account crossings when calculating area and perimeter.
 
-        return (self.perimetersum, self.areasum.abs())
+        return (perimetersum, areasum.abs());
     }
 
     // Return 1 or -1 if crossing prime meridian in east or west direction.
@@ -115,7 +163,7 @@ impl<'a> PolygonArea<'a> {
 
         // Translation from the following cpp code:
         //  https://github.com/geographiclib/geographiclib/blob/main/src/PolygonArea.cpp#L22
-        // 
+        //
         //  lon12 > 0 && ((lon1 < 0 && lon2 >= 0) ||
         //  (lon1 > 0 && lon2 == 0)) ? 1 :
         //  (lon12 < 0 && lon1 >= 0 && lon2 < 0 ? -1 : 0);
@@ -123,14 +171,12 @@ impl<'a> PolygonArea<'a> {
         if lon12 > 0.0 && ((lon1 < 0.0 && lon2 >= 0.0) || (lon1 > 0.0 && lon2 == 0.0)) {
             return 1.0;
         } else if lon12 < 0.0 && lon1 >= 0.0 && lon2 < 0.0 {
-            return -1.0
-        }
-        else {
+            return -1.0;
+        } else {
             return 0.0;
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -473,6 +473,20 @@ mod tests {
         assert_relative_eq!(perimeter, 0.0);
         assert_relative_eq!(area, 0.0);
     }
+    
+    #[test]
+    fn test_planimeter29() {
+        // Check transitdirect vs transit zero handling consistency
+
+        let geoid = Geodesic::wgs84();
+        let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
+        pa.add_point(0.0, 0.0);
+        pa.add_edge(90.0, 1000.0);
+        pa.add_edge(0.0, 1000.0);
+        pa.add_edge(-90.0, 1000.0);
+        let (_, area) = pa.compute();
+        assert_relative_eq!(area, 1000000.0, epsilon = 0.01);   
+    }
 
 
 }

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -633,6 +633,7 @@ mod tests {
     #[test]
     fn test_planimeter29() {
         // Check transitdirect vs transit zero handling consistency
+        // Copied from: https://github.com/geographiclib/geographiclib-js/blob/57137fdcf4ba56718c64b909b00331754b6efceb/geodesic/test/geodesictest.js#L883
 
         let geoid = Geodesic::wgs84();
         let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -9,7 +9,7 @@ const POLYGONAREA_MASK: u64 = caps::LATITUDE | caps::LONGITUDE | caps::DISTANCE 
 #[cfg(feature = "accurate")]
 use accurate::traits::*;
 
-/// Clockwise or Counterclockwise winding
+/// Clockwise or CounterClockwise winding
 /// 
 /// The standard winding of a Simple Feature polygon is counter-clockwise. However, if the polygon is a hole, then the winding is clockwise.
 /// ESRI Shapefile polygons are opposite, with the outer-ring being clockwise and holes being counter-clockwise.

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -1,1 +1,153 @@
-// Port polygonarea.py here if needed
+use crate::Geodesic;
+use crate::geodesic::InverseGeodesic;
+use crate::geodesic::DirectGeodesic;
+use crate::geomath::ang_normalize;
+use crate::geomath::ang_diff;
+
+#[derive(Debug, Clone)]
+pub struct PolygonArea<'a> {
+    geoid: &'a Geodesic,
+    num: usize,
+    areasum: f64,
+    perimetersum: f64,
+    crossings: f64,
+    initial_lat: f64,
+    initial_lon: f64,
+    latest_lat: f64,
+    latest_lon: f64,
+}
+
+// Documentation for PolygonArea
+/// PolygonArea can be used to compute the perimeter and area of a polygon on a Geodesic.
+/// 
+/// # Example
+/// ```rust
+/// use geographiclib_rs::Geodesic;
+/// use geographiclib_rs::polygonarea::PolygonArea;
+///
+/// let g = Geodesic::wgs84();
+/// let mut pa = PolygonArea::new(&g);
+/// 
+/// pa.add_point(0.0, 0.0);
+/// pa.add_point(0.0, 1.0);
+/// pa.add_point(1.0, 1.0);
+/// pa.add_point(1.0, 0.0);
+//// 
+/// let (perimeter, area) = pa.compute();
+///
+/// use approx::assert_relative_eq;
+/// assert_relative_eq!(perimeter, 443770.917248302);
+/// assert_relative_eq!(area, 12308778361.469452);
+/// ```
+impl<'a> PolygonArea<'a> {
+    pub fn new(geoid: &'a Geodesic) -> PolygonArea {
+        PolygonArea {
+            geoid,
+            num: 0,
+            areasum: 0.0,
+            perimetersum: 0.0,
+            crossings: 0.0,
+            initial_lat: 0.0,
+            initial_lon: 0.0,
+            latest_lat: 0.0,
+            latest_lon: 0.0,
+        }
+    }
+
+    /// Add a point to the polygon
+    pub fn add_point(&mut self, lat: f64, lon: f64) {
+        if self.num == 0 {
+            self.initial_lat = lat;
+            self.initial_lon = lon;
+        } else {
+            #[allow(non_snake_case)]
+            let (s12, _azi1, _azi2, _m12, _M12, _M21, S12, _a12) = self.geoid.inverse(self.latest_lat, self.latest_lon, lat, lon);
+            self.perimetersum += s12;
+            self.areasum += S12;
+            self.crossings += PolygonArea::transit(self.latest_lon, lon);
+        }
+        self.latest_lat = lat;
+        self.latest_lon = lon;
+        self.num += 1;
+    }
+
+    /// Add an adge to the polygon using an azimuth (in degrees) and a distance (in meters). This can only be called after at least one point has been added.
+    /// 
+    /// # Panics
+    /// Panics if no points have been added yet.
+    pub fn add_edge(&mut self, azimuth: f64, distance: f64) {
+        if self.num == 0 {
+            panic!("PolygonArea::add_edge: No points added yet");
+        }
+
+        #[allow(non_snake_case)]
+        let (lat, lon, _azi2, _m12, _M12, _M21, S12, _a12) = self.geoid.direct(self.latest_lat, self.latest_lon, azimuth, distance);
+        self.perimetersum += distance;
+        self.areasum += S12;
+        self.crossings += PolygonArea::transit(self.latest_lon, lon);
+        self.latest_lat = lat;
+        self.latest_lon = lon;
+        self.num += 1;
+    }
+
+    /// Return perimeter and area of polygon in meters / meters², consuming PolygonArea.
+    pub fn compute(mut self) -> (f64, f64) {
+        #[allow(non_snake_case)]
+        let (s12, _azi1, _azi2, _m12, _M12, _M21, S12, _a12) = self.geoid.inverse(self.latest_lat, self.latest_lon, self.initial_lat, self.initial_lon);
+        self.perimetersum += s12;
+        self.areasum += S12;
+        self.crossings += PolygonArea::transit(self.latest_lon, self.initial_lon);
+
+        // TODO: Properly take into account crossings when calculating area and perimeter.
+
+        return (self.perimetersum, self.areasum.abs())
+    }
+
+    // Return 1 or -1 if crossing prime meridian in east or west direction.
+    // Otherwise return zero.  longitude = +/-0 considered to be positive.
+    fn transit(lon1: f64, lon2: f64) -> f64 {
+        let (lon12, _lon12s) = ang_diff(lon1, lon2);
+        let lon1 = ang_normalize(lon1);
+        let lon2 = ang_normalize(lon2);
+
+        // Translation from the following cpp code:
+        //  https://github.com/geographiclib/geographiclib/blob/main/src/PolygonArea.cpp#L22
+        // 
+        //  lon12 > 0 && ((lon1 < 0 && lon2 >= 0) ||
+        //  (lon1 > 0 && lon2 == 0)) ? 1 :
+        //  (lon12 < 0 && lon1 >= 0 && lon2 < 0 ? -1 : 0);
+
+        if lon12 > 0.0 && ((lon1 < 0.0 && lon2 >= 0.0) || (lon1 > 0.0 && lon2 == 0.0)) {
+            return 1.0;
+        } else if lon12 < 0.0 && lon1 >= 0.0 && lon2 < 0.0 {
+            return -1.0
+        }
+        else {
+            return 0.0;
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Geodesic;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn test_polygonarea() {
+        let geoid = Geodesic::wgs84();
+        let mut pa = PolygonArea::new(&geoid);
+
+        pa.add_point(0.0, 0.0);
+        pa.add_point(0.0, 1.0);
+        pa.add_point(1.0, 1.0);
+        pa.add_point(1.0, 0.0);
+
+        let (perimeter, area) = pa.compute();
+
+        assert_relative_eq!(perimeter, 443770.917, epsilon = 1.0e-3);
+        assert_relative_eq!(area, 12308778361.469, epsilon = 1.0e-3);
+    }
+}

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -10,10 +10,19 @@ const POLYGONAREA_MASK: u64 = caps::LATITUDE | caps::LONGITUDE | caps::DISTANCE 
 use accurate::traits::*;
 
 /// Clockwise or Counterclockwise winding
+/// 
+/// The standard winding of a Simple Feature polygon is counter-clockwise. However, if the polygon is a hole, then the winding is clockwise.
+/// ESRI Shapefile polygons are opposite, with the outer-ring being clockwise and holes being counter-clockwise.
 #[derive(Debug, Clone)]
 pub enum Winding {
     Clockwise,
     CounterClockwise,
+}
+
+impl Default for Winding {
+    fn default() -> Self {
+        Winding::CounterClockwise
+    }
 }
 
 /// Compute the perimeter and area of a polygon on a Geodesic.

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -109,7 +109,7 @@ impl<'a> PolygonArea<'a> {
         self.num += 1;
     }
 
-    /// Add an adge to the polygon using an azimuth (in degrees) and a distance (in meters). This can only be called after at least one point has been added.
+    /// Add an edge to the polygon using an azimuth (in degrees) and a distance (in meters). This can only be called after at least one point has been added.
     ///
     /// # Panics
     /// Panics if no points have been added yet.

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -159,7 +159,7 @@ impl<'a> PolygonArea<'a> {
     /// pa.add_point(1.0, 1.0);
     /// pa.add_point(0.0, 1.0);
     ///
-    /// let (_perimeter, mut area, _count) = pa.compute(false);
+    /// let (_perimeter, area, _count) = pa.compute(false);
     ///
     /// // Over 5 trillion square meters!
     /// assert_eq!(area, 510053312945726.94); 

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -532,6 +532,11 @@ mod tests {
         assert_relative_eq!(perimeter, 0.0);
         assert_relative_eq!(area, 0.0);
 
+        let result = std::panic::catch_unwind(|| {
+            let (_, _, _) = pa.test_edge(90.0, 1000.0, true);
+        });
+        assert!(result.is_err());
+
         pa.add_point(1.0, 1.0);
         let (perimeter, area, _) = pa.clone().compute(true);
         assert_relative_eq!(perimeter, 0.0);

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -493,7 +493,7 @@ mod tests {
         pa.add_point(1.0, 2.0);
         pa.add_point(3.0, 3.0);
         let (_, area, _) = pa.compute(true);
-        assert_relative_eq!(area, 18454562325.45119);
+        assert_relative_eq!(area, 18454562325.45119, epsilon = 1.0e-4);
 
         // Switching the winding
         let mut pa = PolygonArea::new(&geoid, Winding::Clockwise);
@@ -501,7 +501,7 @@ mod tests {
         pa.add_point(1.0, 2.0);
         pa.add_point(3.0, 3.0);
         let (_, area, _) = pa.compute(true);
-        assert_relative_eq!(area, -18454562325.45119);
+        assert_relative_eq!(area, -18454562325.45119, epsilon = 1.0e-4);
 
         // Swaping lat and lon
         let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
@@ -509,7 +509,7 @@ mod tests {
         pa.add_point(2.0, 1.0);
         pa.add_point(3.0, 3.0);
         let (_, area, _) = pa.compute(true);
-        assert_relative_eq!(area, -18454562325.45119);
+        assert_relative_eq!(area, -18454562325.45119, epsilon = 1.0e-4);
     }
 
     #[test]

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -107,9 +107,9 @@ impl<'a> PolygonArea<'a> {
             self.initial_lon = lon;
         } else {
             #[allow(non_snake_case)]
-            let (_a12, s12, _azi1, _azi2, _m12, _M12, _M21, S12) =
+            let (_a12, s12, _salp1, _calp1, _salp2, _calp2, _m12, _M12, _M21, S12) =
                 self.geoid
-                    ._gen_inverse_azi(self.latest_lat, self.latest_lon, lat, lon, POLYGONAREA_MASK);
+                    ._gen_inverse(self.latest_lat, self.latest_lon, lat, lon, POLYGONAREA_MASK);
             self.perimetersum += s12;
             self.areasum += S12;
             self.crossings += PolygonArea::transit(self.latest_lon, lon);
@@ -337,18 +337,6 @@ mod tests {
 
         assert_relative_eq!(perimeter, 443770.917, epsilon = 1.0e-3);
         assert_relative_eq!(area, -12308778361.469, epsilon = 1.0e-3);
-    }
-
-    #[test]
-    fn test_edge_2() {
-        let geoid = Geodesic::wgs84();
-        let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
-
-        pa.add_point(0.0, 0.0);
-
-        let (_a12, lat2, lon2, _, _, _, _, _, _) = geoid._gen_direct(0.0, 0.0, 90.0, false, 19113000.0, POLYGONAREA_MASK);
-
-        dbg!(lat2, lon2);
     }
 
     #[test]

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -7,6 +7,7 @@ use crate::Geodesic;
 #[cfg(feature = "accurate")]
 use accurate::traits::*;
 
+/// Clockwise or Counterclockise winding
 #[derive(Debug, Clone)]
 pub enum Winding {
     Clockwise,

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -7,7 +7,7 @@ use crate::Geodesic;
 #[cfg(feature = "accurate")]
 use accurate::traits::*;
 
-/// Clockwise or Counterclockise winding
+/// Clockwise or CounterClockise winding
 #[derive(Debug, Clone)]
 pub enum Winding {
     Clockwise,

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -41,6 +41,8 @@ pub struct PolygonArea<'a> {
 /// assert_relative_eq!(area, 12308778361.469452);
 /// ```
 impl<'a> PolygonArea<'a> {
+
+    /// Create a new PolygonArea using a Geodesic.
     pub fn new(geoid: &'a Geodesic) -> PolygonArea {
         PolygonArea {
             geoid,

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -205,7 +205,7 @@ impl<'a> PolygonArea<'a> {
         let lon2 = ang_normalize(lon2);
 
         // Translation from the following cpp code:
-        //  https://github.com/geographiclib/geographiclib/blob/main/src/PolygonArea.cpp#L22
+        //  https://github.com/geographiclib/geographiclib/blob/8bc13eb53acdd8bc4fbe4de212d42dbb29779476/src/PolygonArea.cpp#L22
         //
         //  lon12 > 0 && ((lon1 < 0 && lon2 >= 0) ||
         //  (lon1 > 0 && lon2 == 0)) ? 1 :
@@ -219,6 +219,8 @@ impl<'a> PolygonArea<'a> {
             return 0;
         }
     }
+
+    
 
     fn reduce_area(&self, area: f64, signed: bool) -> f64 {
         let geoid_area = self.geoid.area(); // Area of the planet
@@ -317,7 +319,7 @@ mod tests {
 
     #[test]
     fn test_planimeter0() {
-        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#L644
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/0662e05a432a040a60ab27c779fa09b554177ba9/inst/geographiclib_test.m#L644
 
         let geoid = Geodesic::wgs84();
 
@@ -412,7 +414,7 @@ mod tests {
 
     #[test]
     fn test_planimeter5() {
-        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#L670
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/0662e05a432a040a60ab27c779fa09b554177ba9/inst/geographiclib_test.m#L670
 
         let geoid = Geodesic::wgs84();
         let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
@@ -426,7 +428,7 @@ mod tests {
 
     #[test]
     fn test_planimeter6() {
-        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#L679
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/0662e05a432a040a60ab27c779fa09b554177ba9/inst/geographiclib_test.m#L679
 
         let geoid = Geodesic::wgs84();
 
@@ -465,7 +467,7 @@ mod tests {
 
     #[test]
     fn test_planimeter12() {
-        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#L701
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/0662e05a432a040a60ab27c779fa09b554177ba9/inst/geographiclib_test.m#L701
         let geoid = Geodesic::wgs84();
 
         let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
@@ -479,7 +481,7 @@ mod tests {
 
     #[test]
     fn test_planimeter12r() {
-        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#L710
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/0662e05a432a040a60ab27c779fa09b554177ba9/inst/geographiclib_test.m#L710
         let geoid = Geodesic::wgs84();
 
         let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
@@ -495,7 +497,7 @@ mod tests {
 
     #[test]
     fn test_planimeter13() {
-        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#L719
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/0662e05a432a040a60ab27c779fa09b554177ba9/inst/geographiclib_test.m#L719
 
         let geoid = Geodesic::wgs84();
 
@@ -513,7 +515,7 @@ mod tests {
 
     #[test]
     fn test_planimeter15() {
-        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#LL728C14-L728C26
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/0662e05a432a040a60ab27c779fa09b554177ba9/inst/geographiclib_test.m#LL728C14-L728C26
 
         let geoid = Geodesic::wgs84();
 
@@ -543,7 +545,7 @@ mod tests {
 
     #[test]
     fn test_planimeter21() {
-        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#L752
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/0662e05a432a040a60ab27c779fa09b554177ba9/inst/geographiclib_test.m#L752
 
         // Testing degenrate polygons.
         let geoid = Geodesic::wgs84();

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -13,7 +13,7 @@ use accurate::traits::*;
 /// 
 /// The standard winding of a Simple Feature polygon is counter-clockwise. However, if the polygon is a hole, then the winding is clockwise.
 /// ESRI Shapefile polygons are opposite, with the outer-ring being clockwise and holes being counter-clockwise.
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum Winding {
     Clockwise,
     CounterClockwise,

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -40,7 +40,6 @@ pub struct PolygonArea<'a> {
     latest_lon: f64,
 }
 
-// Documentation for PolygonArea
 /// PolygonArea can be used to compute the perimeter and area of a polygon on a Geodesic.
 ///
 /// # Example
@@ -130,7 +129,7 @@ impl<'a> PolygonArea<'a> {
         self.num += 1;
     }
 
-    /// Return perimeter and area of polygon in meters / meters², consuming PolygonArea.
+    /// Return perimeter (meters) and area (meters²) of the polygon, consuming PolygonArea.
     /// 
     /// # Interpreting negative values
     /// 

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -9,7 +9,7 @@ const POLYGONAREA_MASK: u64 = caps::LATITUDE | caps::LONGITUDE | caps::DISTANCE 
 #[cfg(feature = "accurate")]
 use accurate::traits::*;
 
-/// Clockwise or CounterClockise winding
+/// Clockwise or Counterclockwise winding
 #[derive(Debug, Clone)]
 pub enum Winding {
     Clockwise,

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -364,6 +364,22 @@ mod tests {
         let (perimeter, area) = pa.compute();
         assert_relative_eq!(perimeter, 36026861.0, epsilon = 1.0);
         assert_relative_eq!(area, 0.0, epsilon = 1.0);
+
+        let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
+        pa.add_point(9.0, 0.00000000000001);
+        pa.add_point(9.0, 180.0);
+        pa.add_point(9.0, 0.0);
+        let (perimeter, area) = pa.compute();
+        assert_relative_eq!(perimeter, 36026861.0, epsilon = 1.0);
+        assert_relative_eq!(area, 0.0, epsilon = 1.0);
+
+        let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
+        pa.add_point(9.0, -0.00000000000001);
+        pa.add_point(9.0, 0.0);
+        pa.add_point(9.0, 180.0);
+        let (perimeter, area) = pa.compute();
+        assert_relative_eq!(perimeter, 36026861.0, epsilon = 1.0);
+        assert_relative_eq!(area, 0.0, epsilon = 1.0);
     }
 
     #[test]

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -218,7 +218,7 @@ impl<'a> PolygonArea<'a> {
     }
 
     fn reduce_area(&self, area: f64) -> f64 {
-        let area0 = self.geoid._c2 * 4.0 * std::f64::consts::PI; // Area of earth
+        let area0 = self.geoid._c2 * 4.0 * std::f64::consts::PI; // Area of astronomical body
         let mut area = area % area0;
 
         // Translation of the following cpp code:
@@ -236,8 +236,6 @@ impl<'a> PolygonArea<'a> {
             Winding::Clockwise => area,
             Winding::CounterClockwise => -area,
         };
-
-        dbg!("after winding", area);
 
         // Put area in (-area0/2, area0/2]
         if area > area0/2.0 {

--- a/src/polygonarea.rs
+++ b/src/polygonarea.rs
@@ -268,4 +268,175 @@ mod tests {
         assert_relative_eq!(perimeter, 443770.917, epsilon = 1.0e-3);
         assert_relative_eq!(area, 12308778361.469, epsilon = 1.0e-3);
     }
+
+    #[test]
+    fn test_planimeter0() {
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#L644
+
+        let geoid = Geodesic::wgs84();
+
+        let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
+        pa.add_point(89.0, 0.0);
+        pa.add_point(89.0, 90.0);
+        pa.add_point(89.0, 180.0);
+        pa.add_point(89.0, 270.0);
+        let (perimeter, area) = pa.compute();
+        assert_relative_eq!(perimeter, 631819.8745, epsilon = 1.0e-4);
+        assert_relative_eq!(area, 24952305678.0, epsilon = 1.0);
+
+        // FAILING TEST
+        //let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
+        //pa.add_point(-89.0, 0.0);
+        //pa.add_point(-89.0, 90.0);
+        //pa.add_point(-89.0, 180.0);
+        //pa.add_point(-89.0, 270.0);
+        //let (perimeter, area) = pa.compute();
+        //assert_relative_eq!(perimeter, 631819.8745, epsilon = 1.0e-4);
+        //assert_relative_eq!(area, -24952305678.0, epsilon = 1.0);
+
+        let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
+        pa.add_point(0.0, -1.0);
+        pa.add_point(-1.0, 0.0);
+        pa.add_point(0.0, 1.0);
+        pa.add_point(1.0, 0.0);
+        let (perimeter, area) = pa.compute();
+        assert_relative_eq!(perimeter, 627598.2731, epsilon = 1.0e-4);
+        assert_relative_eq!(area, 24619419146.0, epsilon = 1.0);
+
+
+        let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
+        pa.add_point(90.0, 0.0);
+        pa.add_point(0.0, 0.0);
+        pa.add_point(0.0, 90.0);
+        let (perimeter, area) = pa.compute();
+        assert_relative_eq!(perimeter, 30022685.0, epsilon = 1.0);
+        assert_relative_eq!(area, 63758202715511.0, epsilon = 1.0);
+    }
+
+    #[test]
+    fn test_planimeter5() {
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#L670
+
+        let geoid = Geodesic::wgs84();
+        let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
+        pa.add_point(89.0, 0.1);
+        pa.add_point(89.0, 90.1);
+        pa.add_point(89.0, -179.9);
+        let (perimeter, area) = pa.compute();
+        assert_relative_eq!(perimeter, 539297.0, epsilon = 1.0);
+        assert_relative_eq!(area, 12476152838.5, epsilon = 1.0);
+    }
+
+    #[test]
+    fn test_planimeter6() {
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#L679
+
+        let geoid = Geodesic::wgs84();
+
+        // FAILING TEST: 
+        //let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
+        //pa.add_point(9.0, -0.00000000000001);
+        //pa.add_point(9.0, 180.0);
+        //pa.add_point(9.0, 0.0);
+        //let (perimeter, area) = pa.compute();
+        //assert_relative_eq!(perimeter, 36026861.0, epsilon = 1.0);
+        //assert_relative_eq!(area, 0.0, epsilon = 1.0);
+
+        // FAILING TEST: 
+        //let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
+        //pa.add_point(9.0, 0.00000000000001);
+        //pa.add_point(9.0, 0.0);
+        //pa.add_point(9.0, 180.0);
+        //let (perimeter, area) = pa.compute();
+        //assert_relative_eq!(perimeter, 36026861.0, epsilon = 1.0);
+        //assert_relative_eq!(area, 0.0, epsilon = 1.0);
+    }
+
+    #[test]
+    fn test_planimeter12() {
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#L701
+        let geoid = Geodesic::wgs84();
+
+        let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
+        pa.add_point(66.562222222, 0.0);
+        pa.add_point(66.562222222, 180.0);
+        pa.add_point(66.562222222, 360.0);
+        let (perimeter, area) = pa.compute();
+        assert_relative_eq!(perimeter, 10465729.0, epsilon = 1.0);
+        assert_relative_eq!(area, 0.0);
+    }
+
+    #[test]
+    fn test_planimeter12r() {
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#L710
+        let geoid = Geodesic::wgs84();
+
+        let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
+
+        pa.add_point(66.562222222, -0.0);
+        pa.add_point(66.562222222, -180.0);
+        pa.add_point(66.562222222, -360.0);
+
+        let (perimeter, area) = pa.compute();
+        assert_relative_eq!(perimeter, 10465729.0, epsilon = 1.0);
+        assert_relative_eq!(area, 0.0);
+    }
+
+    #[test]
+    fn test_planimeter13() {
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#L719
+
+        let geoid = Geodesic::wgs84();
+
+        let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
+        pa.add_point(89.0, -360.0);
+        pa.add_point(89.0, -240.0);
+        pa.add_point(89.0, -120.0);
+        pa.add_point(89.0, 0.0);
+        pa.add_point(89.0, 120.0);
+        pa.add_point(89.0, 240.0);
+        let (perimeter, area) = pa.compute();
+        assert_relative_eq!(perimeter, 1160741.0, epsilon = 1.0);
+        assert_relative_eq!(area, 32415230256.0, epsilon = 1.0);
+    }
+
+    #[test]
+    fn test_planimeter15() {
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#LL728C14-L728C26
+
+        let geoid = Geodesic::wgs84();
+
+        let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
+        pa.add_point(2.0, 1.0);
+        pa.add_point(1.0, 2.0);
+        pa.add_point(3.0, 3.0);
+        let (_, area) = pa.compute();
+        assert_relative_eq!(area, 18454562325.45119);
+
+        // Traversing the polygon backwards.
+
+        // FAILING TEST
+        // let mut pa = PolygonArea::new(&geoid, Winding::Clockwise);
+        // pa.add_point(2.0, 1.0);
+        // pa.add_point(1.0, 2.0);
+        // pa.add_point(3.0, 3.0);
+        // let (_, area) = pa.compute();
+        // assert_relative_eq!(area, 18454562325.45119);
+    }
+
+    #[test]
+    fn test_planimeter21() {
+        // Copied from https://github.com/geographiclib/geographiclib-octave/blob/main/inst/geographiclib_test.m#L752
+
+        // Testing degenrate polygons.
+        let geoid = Geodesic::wgs84();
+
+        let mut pa = PolygonArea::new(&geoid, Winding::CounterClockwise);
+        pa.add_point(1.0, 1.0);
+        let (perimeter, area) = pa.compute();
+        assert_relative_eq!(perimeter, 0.0);
+        assert_relative_eq!(area, 0.0);
+    }
+
+
 }


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This PR adds `PolygonArea` for calculating the perimeter and area of a polygon on a Geodesic. It is a port of the PolygonArea class in Geographic Lib (https://github.com/geographiclib/geographiclib/blob/main/src/PolygonArea.cpp). 

This PR also adds `accurate` as an optional dependency (enabled by default), that allows for very accurate summations. This replaces what would have gone in `accumulator.rs`