### PR TITLE
Replace `lazy_static` dependency with `sync::OnceLock`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "geographiclib-rs"
 version = "0.2.3"
 license = "MIT"
 edition = "2018"
+rust-version = "1.70.0"
 
 description = "A port of geographiclib in Rust."
 authors = ["Federico Dolce <psykopear@gmail.com>", "Michael Kirk <michael.code@endoftheworl.de>"]
@@ -23,7 +24,6 @@ test_short = []
 default = ["accurate"]
 
 [dependencies]
-lazy_static = "1.4.0"
 accurate = { version = "0.3", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -4,6 +4,7 @@
 use crate::geodesic_capability as caps;
 use crate::geodesic_line;
 use crate::geomath;
+use std::sync;
 
 use std::f64::consts::{FRAC_1_SQRT_2, PI};
 
@@ -42,13 +43,11 @@ pub struct Geodesic {
     xthresh_: f64,
 }
 
-lazy_static! {
-    static ref WGS84_GEOD: Geodesic = Geodesic::new(WGS84_A, WGS84_F);
-}
+static WGS84_GEOD: sync::OnceLock<Geodesic> = sync::OnceLock::new();
 
 impl Geodesic {
     pub fn wgs84() -> Self {
-        *WGS84_GEOD
+        *WGS84_GEOD.get_or_init(|| Geodesic::new(WGS84_A, WGS84_F))
     }
 
     pub fn equatorial_radius(&self) -> f64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,3 @@ mod geomath;
 mod polygon_area;
 pub use polygon_area::PolygonArea;
 pub use polygon_area::Winding;
-
-#[macro_use]
-extern crate lazy_static;


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Note this bumps the MSRV to 1.70.0.