### PR TITLE
Streamline constants

### DIFF
--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -741,14 +741,14 @@ impl Geodesic {
                     {
                         break;
                     };
-                    if v > 0.0 && (numit > MAX_ITERATIONS || calp1 / salp1 > calp1b / salp1b) {
+                    if v > 0.0 && (numit > ITERATIONS || calp1 / salp1 > calp1b / salp1b) {
                         salp1b = salp1;
                         calp1b = calp1;
-                    } else if v < 0.0 && (numit > MAX_ITERATIONS || calp1 / salp1 < calp1a / salp1a) {
+                    } else if v < 0.0 && (numit > ITERATIONS || calp1 / salp1 < calp1a / salp1a) {
                         salp1a = salp1;
                         calp1a = calp1;
                     }
-                    if numit < MAX_ITERATIONS && dv > 0.0 {
+                    if numit < ITERATIONS && dv > 0.0 {
                         let dalp1 = -v / dv;
                         let sdalp1 = dalp1.sin();
                         let cdalp1 = dalp1.cos();

--- a/src/geodesic_line.rs
+++ b/src/geodesic_line.rs
@@ -16,11 +16,11 @@ pub struct GeodesicLine {
     _B21: f64,
     _B31: f64,
     _B41: f64,
-    _C1a: [f64; GEODESIC_ORDER as usize + 1],
-    _C1pa: [f64; GEODESIC_ORDER as usize + 1],
-    _C2a: [f64; GEODESIC_ORDER as usize + 1],
-    _C3a: [f64; GEODESIC_ORDER as usize],
-    _C4a: [f64; GEODESIC_ORDER as usize],
+    _C1a: [f64; GEODESIC_ORDER + 1],
+    _C1pa: [f64; GEODESIC_ORDER + 1],
+    _C2a: [f64; GEODESIC_ORDER + 1],
+    _C3a: [f64; GEODESIC_ORDER],
+    _C4a: [f64; GEODESIC_ORDER],
     _b: f64,
     _c2: f64,
     _calp0: f64,
@@ -107,13 +107,13 @@ impl GeodesicLine {
         let eps = _k2 / (2.0 * (1.0 + (1.0 + _k2).sqrt()) + _k2);
 
         let mut _A1m1 = 0.0;
-        let mut _C1a: [f64; GEODESIC_ORDER as usize + 1] = [0.0; GEODESIC_ORDER as usize + 1];
+        let mut _C1a: [f64; GEODESIC_ORDER+1] = [0.0; GEODESIC_ORDER+1];
         let mut _B11 = 0.0;
         let mut _stau1 = 0.0;
         let mut _ctau1 = 0.0;
         if caps & caps::CAP_C1 != 0 {
-            _A1m1 = geomath::_A1m1f(eps, geod.GEODESIC_ORDER);
-            geomath::_C1f(eps, &mut _C1a, geod.GEODESIC_ORDER);
+            _A1m1 = geomath::_A1m1f::<GEODESIC_ORDER>(eps);
+            geomath::_C1f::<GEODESIC_ORDER>(eps, &mut _C1a);
             _B11 = geomath::sin_cos_series(true, _ssig1, _csig1, &_C1a);
             let s = _B11.sin();
             let c = _B11.cos();
@@ -121,21 +121,21 @@ impl GeodesicLine {
             _ctau1 = _csig1 * c - _ssig1 * s;
         }
 
-        let mut _C1pa: [f64; GEODESIC_ORDER as usize + 1] = [0.0; GEODESIC_ORDER as usize + 1];
+        let mut _C1pa: [f64; GEODESIC_ORDER+1] = [0.0; GEODESIC_ORDER+1];
         if caps & caps::CAP_C1p != 0 {
-            geomath::_C1pf(eps, &mut _C1pa, geod.GEODESIC_ORDER);
+            geomath::_C1pf::<GEODESIC_ORDER>(eps, &mut _C1pa);
         }
 
         let mut _A2m1 = 0.0;
-        let mut _C2a: [f64; GEODESIC_ORDER as usize + 1] = [0.0; GEODESIC_ORDER as usize + 1];
+        let mut _C2a: [f64; GEODESIC_ORDER+1] = [0.0; GEODESIC_ORDER+1];
         let mut _B21 = 0.0;
         if caps & caps::CAP_C2 != 0 {
-            _A2m1 = geomath::_A2m1f(eps, geod.GEODESIC_ORDER);
-            geomath::_C2f(eps, &mut _C2a, geod.GEODESIC_ORDER);
+            _A2m1 = geomath::_A2m1f::<GEODESIC_ORDER>(eps);
+            geomath::_C2f::<GEODESIC_ORDER>(eps, &mut _C2a);
             _B21 = geomath::sin_cos_series(true, _ssig1, _csig1, &_C2a);
         }
 
-        let mut _C3a: [f64; GEODESIC_ORDER as usize] = [0.0; GEODESIC_ORDER as usize];
+        let mut _C3a: [f64; GEODESIC_ORDER] = [0.0; GEODESIC_ORDER];
         let mut _A3c = 0.0;
         let mut _B31 = 0.0;
         if caps & caps::CAP_C3 != 0 {
@@ -144,7 +144,7 @@ impl GeodesicLine {
             _B31 = geomath::sin_cos_series(true, _ssig1, _csig1, &_C3a);
         }
 
-        let mut _C4a: [f64; GEODESIC_ORDER as usize] = [0.0; GEODESIC_ORDER as usize];
+        let mut _C4a: [f64; GEODESIC_ORDER] = [0.0; GEODESIC_ORDER];
         let mut _A4 = 0.0;
         let mut _B41 = 0.0;
         if caps & caps::CAP_C4 != 0 {


### PR DESCRIPTION
Changes:

* Geodesic fields were are constants (not dependent on spheroid parameters) are now just constants.
* Fixed the type of many constants (i64 -> usize) where applicable.
* Remove arguments that are constants.
* Remove casts that were made redunant by changing i64 -> usize.
* Rewrite polyval; The new version is as close to optimal as my local

This is the first patch in a series of PR aiming at improving performance of geodesic inverse calculation.

- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

