### PR TITLE
Mkirk/usize

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
-on: push
 name: Run tests
+on:
+  - push
+  - pull_request
+  - merge_group
 jobs:
   linting:
     name: formatting and clippy

--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -255,7 +255,7 @@ impl Geodesic {
             }
         } else if outmask & (caps::REDUCEDLENGTH | caps::GEODESICSCALE) != 0 {
             for l in 1..=self.GEODESIC_ORDER {
-                C2a[l as usize] = A1 * C1a[l as usize] - A2 * C2a[l as usize];
+                C2a[l] = A1 * C1a[l] - A2 * C2a[l];
             }
             J12 = m0x * sig12
                 + (geomath::sin_cos_series(true, ssig2, csig2, C2a)
@@ -603,10 +603,10 @@ impl Geodesic {
         let dn1 = (1.0 + self._ep2 * geomath::sq(sbet1)).sqrt();
         let dn2 = (1.0 + self._ep2 * geomath::sq(sbet2)).sqrt();
 
-        const CARR_SIZE: usize = GEODESIC_ORDER as usize + 1;
+        const CARR_SIZE: usize = GEODESIC_ORDER + 1;
         let mut C1a: [f64; CARR_SIZE] = [0.0; CARR_SIZE];
         let mut C2a: [f64; CARR_SIZE] = [0.0; CARR_SIZE];
-        let mut C3a: [f64; GEODESIC_ORDER as usize] = [0.0; GEODESIC_ORDER as usize];
+        let mut C3a: [f64; GEODESIC_ORDER] = [0.0; GEODESIC_ORDER];
 
         let mut meridian = lat1 == -90.0 || slam12 == 0.0;
         let mut calp1 = 0.0;
@@ -823,7 +823,7 @@ impl Geodesic {
                 let A4 = geomath::sq(self.a) * calp0 * salp0 * self._e2;
                 geomath::norm(&mut ssig1, &mut csig1);
                 geomath::norm(&mut ssig2, &mut csig2);
-                let mut C4a: [f64; GEODESIC_ORDER as usize] = [0.0; GEODESIC_ORDER as usize];
+                let mut C4a: [f64; GEODESIC_ORDER] = [0.0; GEODESIC_ORDER];
                 self._C4f(eps, &mut C4a);
                 let B41 = geomath::sin_cos_series(false, ssig1, csig1, &C4a);
                 let B42 = geomath::sin_cos_series(false, ssig2, csig2, &C4a);

--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -121,8 +121,7 @@ impl Geodesic {
         let mut o: usize = 0;
         for (k, j) in (0..GEODESIC_ORDER).rev().enumerate() {
             let m = j.min(GEODESIC_ORDER - j - 1);
-            _A3x[k] = geomath::polyval(m, &COEFF_A3[o..], _n)
-                / COEFF_A3[o + m + 1];
+            _A3x[k] = geomath::polyval(m, &COEFF_A3[o..], _n) / COEFF_A3[o + m + 1];
             o += m + 2;
         }
 
@@ -132,8 +131,7 @@ impl Geodesic {
         for l in 1..GEODESIC_ORDER {
             for j in (l..GEODESIC_ORDER).rev() {
                 let m = j.min(GEODESIC_ORDER - j - 1);
-                _C3x[k] = geomath::polyval(m, &COEFF_C3[o..], _n)
-                    / COEFF_C3[o + m + 1];
+                _C3x[k] = geomath::polyval(m, &COEFF_C3[o..], _n) / COEFF_C3[o + m + 1];
                 k += 1;
                 o += m + 2;
             }
@@ -145,8 +143,7 @@ impl Geodesic {
         for l in 0..GEODESIC_ORDER {
             for j in (l..GEODESIC_ORDER).rev() {
                 let m = GEODESIC_ORDER - j - 1;
-                _C4x[k] = geomath::polyval(m, &COEFF_C4[o..], _n)
-                    / COEFF_C4[o + m + 1];
+                _C4x[k] = geomath::polyval(m, &COEFF_C4[o..], _n) / COEFF_C4[o + m + 1];
                 k += 1;
                 o += m + 2;
             }
@@ -188,12 +185,7 @@ impl Geodesic {
     pub fn _C3f(&self, eps: f64, c: &mut [f64]) {
         let mut mult = 1.0;
         let mut o = 0;
-        for (l, c_item) in c
-            .iter_mut()
-            .enumerate()
-            .take(self.GEODESIC_ORDER)
-            .skip(1)
-        {
+        for (l, c_item) in c.iter_mut().enumerate().take(self.GEODESIC_ORDER).skip(1) {
             let m = self.GEODESIC_ORDER - l - 1;
             mult *= eps;
             *c_item = mult * geomath::polyval(m, &self._C3x[o..], eps);

--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -25,13 +25,13 @@ pub struct Geodesic {
     pub _b: f64,
     pub _c2: f64,
     _etol2: f64,
-    _A3x: [f64; GEODESIC_ORDER as usize],
-    _C3x: [f64; _nC3x_ as usize],
-    _C4x: [f64; _nC4x_ as usize],
+    _A3x: [f64; GEODESIC_ORDER],
+    _C3x: [f64; _nC3x_],
+    _C4x: [f64; _nC4x_],
 
-    pub GEODESIC_ORDER: i64,
-    _nC3x_: i64,
-    _nC4x_: i64,
+    pub GEODESIC_ORDER: usize,
+    _nC3x_: usize,
+    _nC4x_: usize,
     maxit1_: u64,
     maxit2_: u64,
 
@@ -80,11 +80,11 @@ const COEFF_C4: [f64; 77] = [
     -3328.0, 1144.0, 315315.0, -128.0, 135135.0, -2560.0, 832.0, 405405.0, 128.0, 99099.0,
 ];
 
-pub const GEODESIC_ORDER: i64 = 6;
+pub const GEODESIC_ORDER: usize = 6;
 #[allow(non_upper_case_globals)]
-const _nC3x_: i64 = 15;
+const _nC3x_: usize = 15;
 #[allow(non_upper_case_globals)]
-const _nC4x_: i64 = 21;
+const _nC4x_: usize = 21;
 
 impl Geodesic {
     pub fn new(a: f64, f: f64) -> Self {
@@ -113,42 +113,40 @@ impl Geodesic {
             / 2.0;
         let _etol2 = 0.1 * _tol2_ / (f.abs().max(0.001) * (1.0 - f / 2.0).min(1.0) / 2.0).sqrt();
 
-        let mut _A3x: [f64; GEODESIC_ORDER as usize] = [0.0; GEODESIC_ORDER as usize];
-        let mut _C3x: [f64; _nC3x_ as usize] = [0.0; _nC3x_ as usize];
-        let mut _C4x: [f64; _nC4x_ as usize] = [0.0; _nC4x_ as usize];
+        let mut _A3x: [f64; GEODESIC_ORDER] = [0.0; GEODESIC_ORDER];
+        let mut _C3x: [f64; _nC3x_] = [0.0; _nC3x_];
+        let mut _C4x: [f64; _nC4x_] = [0.0; _nC4x_];
 
         // Call a3coeff
-        let mut o: i64 = 0;
+        let mut o: usize = 0;
         for (k, j) in (0..GEODESIC_ORDER).rev().enumerate() {
             let m = j.min(GEODESIC_ORDER - j - 1);
-            _A3x[k] = geomath::polyval(m as isize, &COEFF_A3[o as usize..], _n)
-                / COEFF_A3[(o + m + 1) as usize];
+            _A3x[k] = geomath::polyval(m, &COEFF_A3[o..], _n)
+                / COEFF_A3[o + m + 1];
             o += m + 2;
         }
 
         // c3coeff
-        let mut o: i64 = 0;
+        let mut o = 0;
         let mut k = 0;
-
         for l in 1..GEODESIC_ORDER {
             for j in (l..GEODESIC_ORDER).rev() {
                 let m = j.min(GEODESIC_ORDER - j - 1);
-                _C3x[k as usize] = geomath::polyval(m as isize, &COEFF_C3[o as usize..], _n)
-                    / COEFF_C3[(o + m + 1) as usize];
+                _C3x[k] = geomath::polyval(m, &COEFF_C3[o..], _n)
+                    / COEFF_C3[o + m + 1];
                 k += 1;
                 o += m + 2;
             }
         }
 
         // c4coeff
-        let mut o: i64 = 0;
+        let mut o = 0;
         let mut k = 0;
-
         for l in 0..GEODESIC_ORDER {
             for j in (l..GEODESIC_ORDER).rev() {
                 let m = GEODESIC_ORDER - j - 1;
-                _C4x[k as usize] = geomath::polyval(m as isize, &COEFF_C4[o as usize..], _n)
-                    / COEFF_C4[(o + m + 1) as usize];
+                _C4x[k] = geomath::polyval(m, &COEFF_C4[o..], _n)
+                    / COEFF_C4[o + m + 1];
                 k += 1;
                 o += m + 2;
             }
@@ -184,7 +182,7 @@ impl Geodesic {
     }
 
     pub fn _A3f(&self, eps: f64) -> f64 {
-        geomath::polyval(self.GEODESIC_ORDER as isize - 1, &self._A3x, eps)
+        geomath::polyval(self.GEODESIC_ORDER - 1, &self._A3x, eps)
     }
 
     pub fn _C3f(&self, eps: f64, c: &mut [f64]) {
@@ -193,12 +191,12 @@ impl Geodesic {
         for (l, c_item) in c
             .iter_mut()
             .enumerate()
-            .take(self.GEODESIC_ORDER as usize)
+            .take(self.GEODESIC_ORDER)
             .skip(1)
         {
-            let m = self.GEODESIC_ORDER as usize - l - 1;
+            let m = self.GEODESIC_ORDER - l - 1;
             mult *= eps;
-            *c_item = mult * geomath::polyval(m as isize, &self._C3x[o..], eps);
+            *c_item = mult * geomath::polyval(m, &self._C3x[o..], eps);
             o += m + 1;
         }
     }
@@ -206,9 +204,9 @@ impl Geodesic {
     pub fn _C4f(&self, eps: f64, c: &mut [f64]) {
         let mut mult = 1.0;
         let mut o = 0;
-        for (l, c_item) in c.iter_mut().enumerate().take(self.GEODESIC_ORDER as usize) {
-            let m = self.GEODESIC_ORDER as usize - l - 1;
-            *c_item = mult * geomath::polyval(m as isize, &self._C4x[o..], eps);
+        for (l, c_item) in c.iter_mut().enumerate().take(self.GEODESIC_ORDER) {
+            let m = self.GEODESIC_ORDER - l - 1;
+            *c_item = mult * geomath::polyval(m, &self._C4x[o..], eps);
             o += m + 1;
             mult *= eps;
         }

--- a/src/geodesic_line.rs
+++ b/src/geodesic_line.rs
@@ -16,11 +16,11 @@ pub struct GeodesicLine {
     _B21: f64,
     _B31: f64,
     _B41: f64,
-    _C1a: [f64; GEODESIC_ORDER as usize + 1],
-    _C1pa: [f64; GEODESIC_ORDER as usize + 1],
-    _C2a: [f64; GEODESIC_ORDER as usize + 1],
-    _C3a: [f64; GEODESIC_ORDER as usize],
-    _C4a: [f64; GEODESIC_ORDER as usize],
+    _C1a: [f64; GEODESIC_ORDER + 1],
+    _C1pa: [f64; GEODESIC_ORDER + 1],
+    _C2a: [f64; GEODESIC_ORDER + 1],
+    _C3a: [f64; GEODESIC_ORDER],
+    _C4a: [f64; GEODESIC_ORDER],
     _b: f64,
     _c2: f64,
     _calp0: f64,
@@ -107,7 +107,7 @@ impl GeodesicLine {
         let eps = _k2 / (2.0 * (1.0 + (1.0 + _k2).sqrt()) + _k2);
 
         let mut _A1m1 = 0.0;
-        let mut _C1a: [f64; GEODESIC_ORDER as usize + 1] = [0.0; GEODESIC_ORDER as usize + 1];
+        let mut _C1a: [f64; GEODESIC_ORDER + 1] = [0.0; GEODESIC_ORDER + 1];
         let mut _B11 = 0.0;
         let mut _stau1 = 0.0;
         let mut _ctau1 = 0.0;
@@ -121,13 +121,13 @@ impl GeodesicLine {
             _ctau1 = _csig1 * c - _ssig1 * s;
         }
 
-        let mut _C1pa: [f64; GEODESIC_ORDER as usize + 1] = [0.0; GEODESIC_ORDER as usize + 1];
+        let mut _C1pa: [f64; GEODESIC_ORDER + 1] = [0.0; GEODESIC_ORDER + 1];
         if caps & caps::CAP_C1p != 0 {
             geomath::_C1pf(eps, &mut _C1pa, geod.GEODESIC_ORDER);
         }
 
         let mut _A2m1 = 0.0;
-        let mut _C2a: [f64; GEODESIC_ORDER as usize + 1] = [0.0; GEODESIC_ORDER as usize + 1];
+        let mut _C2a: [f64; GEODESIC_ORDER + 1] = [0.0; GEODESIC_ORDER + 1];
         let mut _B21 = 0.0;
         if caps & caps::CAP_C2 != 0 {
             _A2m1 = geomath::_A2m1f(eps, geod.GEODESIC_ORDER);
@@ -135,7 +135,7 @@ impl GeodesicLine {
             _B21 = geomath::sin_cos_series(true, _ssig1, _csig1, &_C2a);
         }
 
-        let mut _C3a: [f64; GEODESIC_ORDER as usize] = [0.0; GEODESIC_ORDER as usize];
+        let mut _C3a: [f64; GEODESIC_ORDER] = [0.0; GEODESIC_ORDER];
         let mut _A3c = 0.0;
         let mut _B31 = 0.0;
         if caps & caps::CAP_C3 != 0 {
@@ -144,7 +144,7 @@ impl GeodesicLine {
             _B31 = geomath::sin_cos_series(true, _ssig1, _csig1, &_C3a);
         }
 
-        let mut _C4a: [f64; GEODESIC_ORDER as usize] = [0.0; GEODESIC_ORDER as usize];
+        let mut _C4a: [f64; GEODESIC_ORDER] = [0.0; GEODESIC_ORDER];
         let mut _A4 = 0.0;
         let mut _B41 = 0.0;
         if caps & caps::CAP_C4 != 0 {

--- a/src/geomath.rs
+++ b/src/geomath.rs
@@ -290,7 +290,7 @@ pub fn astroid(x: f64, y: f64) -> f64 {
 pub fn _A1m1f(eps: f64, geodesic_order: usize) -> f64 {
     const COEFF: [f64; 5] = [1.0, 4.0, 64.0, 0.0, 256.0];
     let m = geodesic_order / 2;
-    let t = polyval(m , &COEFF, sq(eps)) / COEFF[m + 1];
+    let t = polyval(m, &COEFF, sq(eps)) / COEFF[m + 1];
     (t + eps) / (1.0 - eps)
 }
 
@@ -304,8 +304,7 @@ pub fn _C1f(eps: f64, c: &mut [f64], geodesic_order: usize) {
     let mut o = 0;
     for l in 1..=geodesic_order {
         let m = (geodesic_order - l) / 2;
-        c[l] =
-            d * polyval(m , &COEFF[o..], eps2) / COEFF[o + m + 1];
+        c[l] = d * polyval(m, &COEFF[o..], eps2) / COEFF[o + m + 1];
         o += m + 2;
         d *= eps;
     }
@@ -321,8 +320,7 @@ pub fn _C1pf(eps: f64, c: &mut [f64], geodesic_order: usize) {
     let mut o = 0;
     for l in 1..=geodesic_order {
         let m = (geodesic_order - l) / 2;
-        c[l] =
-            d * polyval(m , &COEFF[o..], eps2) / COEFF[o + m + 1];
+        c[l] = d * polyval(m, &COEFF[o..], eps2) / COEFF[o + m + 1];
         o += m + 2;
         d *= eps;
     }
@@ -331,7 +329,7 @@ pub fn _C1pf(eps: f64, c: &mut [f64], geodesic_order: usize) {
 pub fn _A2m1f(eps: f64, geodesic_order: usize) -> f64 {
     const COEFF: [f64; 5] = [-11.0, -28.0, -192.0, 0.0, 256.0];
     let m = geodesic_order / 2;
-    let t = polyval(m , &COEFF, sq(eps)) / COEFF[m + 1];
+    let t = polyval(m, &COEFF, sq(eps)) / COEFF[m + 1];
     (t - eps) / (1.0 + eps)
 }
 
@@ -345,8 +343,7 @@ pub fn _C2f(eps: f64, c: &mut [f64], geodesic_order: usize) {
     let mut o = 0;
     for l in 1..=geodesic_order {
         let m = (geodesic_order - l) / 2;
-        c[l] =
-            d * polyval(m , &COEFF[o..], eps2) / COEFF[o + m + 1];
+        c[l] = d * polyval(m, &COEFF[o..], eps2) / COEFF[o + m + 1];
         o += m + 2;
         d *= eps;
     }

--- a/src/geomath.rs
+++ b/src/geomath.rs
@@ -52,16 +52,12 @@ pub fn sum(u: f64, v: f64) -> (f64, f64) {
 }
 
 // Evaluate a polynomial
-pub fn polyval(n: isize, p: &[f64], x: f64) -> f64 {
-    if n < 0 {
-        0.0
-    } else {
-        let mut y = p[0];
-        for val in &p[1..=n as usize] {
-            y = y * x + val;
-        }
-        y
+pub fn polyval(n: usize, p: &[f64], x: f64) -> f64 {
+    let mut y = p[0];
+    for val in &p[1..=n] {
+        y = y * x + val;
     }
+    y
 }
 
 // Round an angle so taht small values underflow to 0
@@ -291,14 +287,14 @@ pub fn astroid(x: f64, y: f64) -> f64 {
     }
 }
 
-pub fn _A1m1f(eps: f64, geodesic_order: i64) -> f64 {
+pub fn _A1m1f(eps: f64, geodesic_order: usize) -> f64 {
     const COEFF: [f64; 5] = [1.0, 4.0, 64.0, 0.0, 256.0];
-    let m: i64 = geodesic_order / 2;
-    let t = polyval(m as isize, &COEFF, sq(eps)) / COEFF[(m + 1) as usize];
+    let m = geodesic_order / 2;
+    let t = polyval(m , &COEFF, sq(eps)) / COEFF[m + 1];
     (t + eps) / (1.0 - eps)
 }
 
-pub fn _C1f(eps: f64, c: &mut [f64], geodesic_order: i64) {
+pub fn _C1f(eps: f64, c: &mut [f64], geodesic_order: usize) {
     const COEFF: [f64; 18] = [
         -1.0, 6.0, -16.0, 32.0, -9.0, 64.0, -128.0, 2048.0, 9.0, -16.0, 768.0, 3.0, -5.0, 512.0,
         -7.0, 1280.0, -7.0, 2048.0,
@@ -308,14 +304,14 @@ pub fn _C1f(eps: f64, c: &mut [f64], geodesic_order: i64) {
     let mut o = 0;
     for l in 1..=geodesic_order {
         let m = (geodesic_order - l) / 2;
-        c[l as usize] =
-            d * polyval(m as isize, &COEFF[o as usize..], eps2) / COEFF[(o + m + 1) as usize];
+        c[l] =
+            d * polyval(m , &COEFF[o..], eps2) / COEFF[o + m + 1];
         o += m + 2;
         d *= eps;
     }
 }
 
-pub fn _C1pf(eps: f64, c: &mut [f64], geodesic_order: i64) {
+pub fn _C1pf(eps: f64, c: &mut [f64], geodesic_order: usize) {
     const COEFF: [f64; 18] = [
         205.0, -432.0, 768.0, 1536.0, 4005.0, -4736.0, 3840.0, 12288.0, -225.0, 116.0, 384.0,
         -7173.0, 2695.0, 7680.0, 3467.0, 7680.0, 38081.0, 61440.0,
@@ -325,21 +321,21 @@ pub fn _C1pf(eps: f64, c: &mut [f64], geodesic_order: i64) {
     let mut o = 0;
     for l in 1..=geodesic_order {
         let m = (geodesic_order - l) / 2;
-        c[l as usize] =
-            d * polyval(m as isize, &COEFF[o as usize..], eps2) / COEFF[(o + m + 1) as usize];
+        c[l] =
+            d * polyval(m , &COEFF[o..], eps2) / COEFF[o + m + 1];
         o += m + 2;
         d *= eps;
     }
 }
 
-pub fn _A2m1f(eps: f64, geodesic_order: i64) -> f64 {
+pub fn _A2m1f(eps: f64, geodesic_order: usize) -> f64 {
     const COEFF: [f64; 5] = [-11.0, -28.0, -192.0, 0.0, 256.0];
-    let m: i64 = geodesic_order / 2;
-    let t = polyval(m as isize, &COEFF, sq(eps)) / COEFF[(m + 1) as usize];
+    let m = geodesic_order / 2;
+    let t = polyval(m , &COEFF, sq(eps)) / COEFF[m + 1];
     (t - eps) / (1.0 + eps)
 }
 
-pub fn _C2f(eps: f64, c: &mut [f64], geodesic_order: i64) {
+pub fn _C2f(eps: f64, c: &mut [f64], geodesic_order: usize) {
     const COEFF: [f64; 18] = [
         1.0, 2.0, 16.0, 32.0, 35.0, 64.0, 384.0, 2048.0, 15.0, 80.0, 768.0, 7.0, 35.0, 512.0, 63.0,
         1280.0, 77.0, 2048.0,
@@ -349,8 +345,8 @@ pub fn _C2f(eps: f64, c: &mut [f64], geodesic_order: i64) {
     let mut o = 0;
     for l in 1..=geodesic_order {
         let m = (geodesic_order - l) / 2;
-        c[l as usize] =
-            d * polyval(m as isize, &COEFF[o as usize..], eps2) / COEFF[(o + m + 1) as usize];
+        c[l] =
+            d * polyval(m , &COEFF[o..], eps2) / COEFF[o + m + 1];
         o += m + 2;
         d *= eps;
     }

--- a/src/geomath.rs
+++ b/src/geomath.rs
@@ -302,6 +302,9 @@ pub fn _C1f(eps: f64, c: &mut [f64], geodesic_order: usize) {
     let eps2 = sq(eps);
     let mut d = eps;
     let mut o = 0;
+    // Clippy wants us to turn this into `c.iter_mut().enumerate().take(geodesic_order + 1).skip(1)`
+    // but benching (rust-1.75) shows that it would be slower.
+    #[allow(clippy::needless_range_loop)]
     for l in 1..=geodesic_order {
         let m = (geodesic_order - l) / 2;
         c[l] = d * polyval(m, &COEFF[o..], eps2) / COEFF[o + m + 1];
@@ -318,6 +321,9 @@ pub fn _C1pf(eps: f64, c: &mut [f64], geodesic_order: usize) {
     let eps2 = sq(eps);
     let mut d = eps;
     let mut o = 0;
+    // Clippy wants us to turn this into `c.iter_mut().enumerate().take(geodesic_order + 1).skip(1)`
+    // but benching (rust-1.75) shows that it would be slower.
+    #[allow(clippy::needless_range_loop)]
     for l in 1..=geodesic_order {
         let m = (geodesic_order - l) / 2;
         c[l] = d * polyval(m, &COEFF[o..], eps2) / COEFF[o + m + 1];
@@ -341,6 +347,9 @@ pub fn _C2f(eps: f64, c: &mut [f64], geodesic_order: usize) {
     let eps2 = sq(eps);
     let mut d = eps;
     let mut o = 0;
+    // Clippy wants us to turn this into `c.iter_mut().enumerate().take(geodesic_order + 1).skip(1)`
+    // but benching (rust-1.75) shows that it would be slower.
+    #[allow(clippy::needless_range_loop)]
     for l in 1..=geodesic_order {
         let m = (geodesic_order - l) / 2;
         c[l] = d * polyval(m, &COEFF[o..], eps2) / COEFF[o + m + 1];


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Supersedes #57 - essentially reverting some of the clippy suggestions.

```
$ cargo bench --bench="*" --  --baseline=main-2024-01-24/
   Compiling geographiclib-rs v0.2.3 (/Users/mkirk/src/georust/geographiclib-rs)
    Finished bench [optimized] target(s) in 1.11s
     Running benches/geodesic_benchmark.rs (target/release/deps/geodesic_benchmark-656e1aa161ec181c)
direct (c wrapper)/default
                        time:   [24.055 µs 24.116 µs 24.196 µs]
                        change: [+0.5925% +0.8104% +1.0284%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe

direct (rust impl)/default
                        time:   [29.099 µs 29.129 µs 29.163 µs]
                        change: [-3.0292% -2.8670% -2.7039%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe

inverse (c wrapper)/default
                        time:   [44.773 µs 44.843 µs 44.924 µs]
                        change: [-2.0456% -0.5606% +0.4443%] (p = 0.49 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

inverse (rust impl)/default
                        time:   [77.147 µs 77.215 µs 77.290 µs]
                        change: [+4.3024% +4.4502% +4.6044%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
```

I did some profiling to see if I could account for the losses in the "inverse" case. Seemingly the biggest offender is an increase in the time spent in `atan2`. We haven't explicitly changed how we call that method, so I'm not sure what to make of it, but I'm willing to call the gains and losses a wash vs `main`, and merge this based on the readability improvements.