### PR TITLE
remove sincosd

### DIFF
--- a/src/geodesic_line.rs
+++ b/src/geodesic_line.rs
@@ -80,14 +80,14 @@ impl GeodesicLine {
         let caps = caps | caps::LATITUDE | caps::AZIMUTH | caps::LONG_UNROLL;
         let (azi1, salp1, calp1) = if salp1.is_nan() || calp1.is_nan() {
             let azi1 = geomath::ang_normalize(azi1);
-            let (salp1, calp1) = geomath::sincosd(geomath::ang_round(azi1));
+            let (salp1, calp1) = azi1.to_radians().sin_cos();
             (azi1, salp1, calp1)
         } else {
             (azi1, salp1, calp1)
         };
         let lat1 = geomath::lat_fix(lat1);
 
-        let (mut sbet1, mut cbet1) = geomath::sincosd(geomath::ang_round(lat1));
+        let (mut sbet1, mut cbet1) = geomath::ang_round(lat1).to_radians().sin_cos();
         sbet1 *= _f1;
         geomath::norm(&mut sbet1, &mut cbet1);
         cbet1 = tiny_.max(cbet1);
@@ -227,11 +227,8 @@ impl GeodesicLine {
         let mut csig2: f64;
         if arcmode {
             sig12 = s12_a12.to_radians();
-            let res = geomath::sincosd(s12_a12);
-            ssig12 = res.0;
-            csig12 = res.1;
+            (ssig12, csig12) = sig12.sin_cos();
         } else {
-            // tau12 = s12_a12 / (self._b * (1 + self._A1m1))
             let tau12 = s12_a12 / (self._b * (1.0 + self._A1m1));
 
             let s = tau12.sin();

--- a/src/geomath.rs
+++ b/src/geomath.rs
@@ -136,68 +136,6 @@ pub fn ang_diff(x: f64, y: f64) -> (f64, f64) {
     }
 }
 
-pub fn fmod(x: f64, y: f64) -> f64 {
-    x % y
-}
-
-/// Compute sine and cosine of x in degrees
-pub fn sincosd(x: f64) -> (f64, f64) {
-    // r = math.fmod(x, 360) if Math.isfinite(x) else Math.nan
-    let mut r = if x.is_finite() {
-        fmod(x, 360.0)
-    } else {
-        std::f64::NAN
-    };
-
-    // q = 0 if Math.isnan(r) else int(round(r / 90))
-    let mut q = if r.is_nan() {
-        0
-    } else {
-        (r / 90.0).round() as i32
-    };
-
-    // r -= 90 * q; r = math.radians(r)
-    r -= 90.0 * q as f64;
-    r = r.to_radians();
-
-    // s = math.sin(r); c = math.cos(r)
-    let s = r.sin();
-    let c = r.cos();
-
-    // q = q % 4
-    q %= 4;
-
-    // if q == 1:
-    //     s, c =  c, -s
-    // elif q == 2:
-    //     s, c = -s, -c
-    // elif q == 3:
-    //     s, c = -c,  s
-
-    let q = if q < 0 { q + 4 } else { q };
-
-    let (s, c) = if q == 1 {
-        (c, -s)
-    } else if q == 2 {
-        (-s, -c)
-    } else if q == 3 {
-        (-c, s)
-    } else {
-        debug_assert_eq!(q, 0);
-        (s, c)
-    };
-
-    // # Remove the minus sign on -0.0 except for sin(-0.0).
-    // # On Windows 32-bit with python 2.7, math.fmod(-0.0, 360) = +0.0
-    // # (x, c) here fixes this bug.  See also Math::sincosd in the C++ library.
-    // # AngNormalize has a similar fix.
-    //     s, c = (x, c) if x == 0 else (0.0+s, 0.0+c)
-    // return s, c
-    let (s, c) = if x == 0.0 { (x, c) } else { (0.0 + s, 0.0 + c) };
-
-    (s, c)
-}
-
 // Compute atan2(y, x) with result in degrees
 pub fn atan2d(y: f64, x: f64) -> f64 {
     let mut x = x;
@@ -361,22 +299,7 @@ pub fn _C2f(eps: f64, c: &mut [f64], geodesic_order: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use approx::assert_relative_eq;
     // Results for the assertions are taken by running the python implementation
-
-    #[test]
-    fn test_sincosd() {
-        let res = sincosd(-77.03196);
-        assert_relative_eq!(res.0, -0.9744953925159129);
-        assert_relative_eq!(res.1, 0.22440750870961693);
-
-        let res = sincosd(69.48894);
-        assert_relative_eq!(res.0, 0.9366045700708676);
-        assert_relative_eq!(res.1, 0.3503881837653281);
-        let res = sincosd(-1.0);
-        assert_relative_eq!(res.0, -0.01745240643728351);
-        assert_relative_eq!(res.1, 0.9998476951563913);
-    }
 
     #[test]
     fn test__C2f() {


### PR DESCRIPTION
As a side effect also remove fmod (as now it is deadcode)

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.

---

Two Regressions. One minor & One Major

When solving the direct problem, bad values `f64::INFINITE` & `f64::NAN` won't result in the output being `0`, only extremely close to `0`. Not really worried about this, sort of falls in the case of "_garbage in, garbage out_".


1/50k of the GeodTest.dat cases fails 😱 (by 6.9e-7 the % error is 3e-12). This (AFAIT) comes down to [quadrant normalization](https://github.com/georust/geographiclib-rs/blob/a9b8f921a543e84a39c8ed16b06c58fe59e1fe95/src/geomath.rs#L160). It down is seems that `sincosd` differs from `.to_radians().sin_cos()` by `~1e-16` when dealing with values _extremely close_ to +/-180°. 

In my local testing
![image](https://github.com/georust/geographiclib-rs/assets/19227148/06a73d69-5bd0-4702-aff1-f8196d950015)

It is amusing at the `atan2` of the 2 values is correct to within `e-16`, but just not the sin/cos.

Technically a regression, by nearly the smallest order (I'm not joking, there are only 2 64bit floating point values between the two results). I'll let project management judge if that is deal breaking. 