### PR TITLE
Make `GeodesicLine` public

### DIFF
--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -912,10 +912,10 @@ impl Geodesic {
 /// Place a second point, given the first point, an azimuth, and a distance.
 ///
 /// # Arguments
-///   - lat1 - Latitude of 1st point [degrees] [-90.,90.]
-///   - lon1 - Longitude of 1st point [degrees] [-180., 180.]
-///   - azi1 - Azimuth at 1st point [degrees] [-180., 180.]
-///   - s12 - Distance from 1st to 2nd point [meters] Value may be negative
+///   - lat1 - Latitude of 1st point (degrees) [-90.,90.]
+///   - lon1 - Longitude of 1st point (degrees) [-180., 180.]
+///   - azi1 - Azimuth at 1st point (degrees) [-180., 180.]
+///   - s12 - Distance from 1st to 2nd point (meters) Value may be negative
 ///
 /// # Returns
 ///

--- a/src/geodesic_capability.rs
+++ b/src/geodesic_capability.rs
@@ -11,15 +11,15 @@ pub const OUT_ALL: u64 = 0x7F80;
 // Includes LONG_UNROLL
 pub const OUT_MASK: u64 = 0xFF80;
 pub const EMPTY: u64 = 0;
-pub const LATITUDE: u64 = 1 << 7 | CAP_NONE;
-pub const LONGITUDE: u64 = 1 << 8 | CAP_C3;
-pub const AZIMUTH: u64 = 1 << 9 | CAP_NONE;
-pub const DISTANCE: u64 = 1 << 10 | CAP_C1;
+pub const LATITUDE: u64 = (1 << 7) | CAP_NONE;
+pub const LONGITUDE: u64 = (1 << 8) | CAP_C3;
+pub const AZIMUTH: u64 = (1 << 9) | CAP_NONE;
+pub const DISTANCE: u64 = (1 << 10) | CAP_C1;
 pub const STANDARD: u64 = LATITUDE | LONGITUDE | AZIMUTH | DISTANCE;
-pub const DISTANCE_IN: u64 = 1 << 11 | CAP_C1 | CAP_C1p;
-pub const REDUCEDLENGTH: u64 = 1 << 12 | CAP_C1 | CAP_C2;
-pub const GEODESICSCALE: u64 = 1 << 13 | CAP_C1 | CAP_C2;
-pub const AREA: u64 = 1 << 14 | CAP_C4;
+pub const DISTANCE_IN: u64 = (1 << 11) | CAP_C1 | CAP_C1p;
+pub const REDUCEDLENGTH: u64 = (1 << 12) | CAP_C1 | CAP_C2;
+pub const GEODESICSCALE: u64 = (1 << 13) | CAP_C1 | CAP_C2;
+pub const AREA: u64 = (1 << 14) | CAP_C4;
 pub const LONG_UNROLL: u64 = 1 << 15;
 // Does not include LONG_UNROLL
 pub const ALL: u64 = OUT_ALL | CAP_ALL;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub mod geodesic_capability;
 pub use geodesic_capability as capability;
 
 mod geodesic_line;
+pub use geodesic_line::GeodesicLine;
 mod geomath;
 mod polygon_area;
 pub use polygon_area::PolygonArea;

--- a/src/polygon_area.rs
+++ b/src/polygon_area.rs
@@ -69,7 +69,7 @@ pub struct PolygonArea<'a> {
 /// ```
 impl<'a> PolygonArea<'a> {
     /// Create a new PolygonArea using a Geodesic.
-    pub fn new(geoid: &'a Geodesic, winding: Winding) -> PolygonArea {
+    pub fn new(geoid: &'a Geodesic, winding: Winding) -> Self {
         PolygonArea {
             geoid,
             winding,


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I'd like to make `GeodesicLine` public to be able to skip repeating all of [this](https://github.com/georust/geographiclib-rs/blob/dec5cd7db63a4f20fe3c5f51bba034e9cb640334/src/geodesic_line.rs#L59-L157) when computing multiple points along the same line.