### PR TITLE
Exclude benchmark data from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/georust/geographiclib-rs"
 keywords = ["gis", "geo", "geography", "geospatial"]
 documentation = "https://docs.rs/geographiclib-rs"
 readme = "README.md"
+include = ["README.md", "src/**/*.rs"]
 
 [features]
 # Run tests against Karney's GeodTest.dat test cases.


### PR DESCRIPTION
This commit excludes the benchmark data and the benchmark from the published crate. This minimizes the size of the uploaded tar ball by nearly 20% (from 54kb to 41kb). I'm not aware any useful reason to run benchmarks from the published source code, so there shouldn't be any downside in doing that.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
The reduced size translates to a traffic decrease of 22 GB for crates.io over 90 days using the 1.7 million downloads as listed by crates.io baseline.

This was found while reviewing dependency updates via diff.rs: https://diff.weiznich.de/geographiclib-rs/0.2.4/0.2.5/test_fixtures%2FGeodTest-100.dat

I opted for the `include` variant to make sure only explicitly wanted files are included in the future. See [the cargo documentation for more details](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields).