### PR TITLE
exclude test fixture data from published crate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Exclude test fixture data from published crate to reduce published crate size by ~10kb
+  * Thanks to @weiznich for the inspiration
+  * <https://github.com/georust/geographiclib-rs/pull/66>
+
 ## 0.2.5
 
 * Make `GeodesicLine` public, which can be more efficient when placing multiple points along a single line.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/georust/geographiclib-rs"
 keywords = ["gis", "geo", "geography", "geospatial"]
 documentation = "https://docs.rs/geographiclib-rs"
 readme = "README.md"
+exclude = ["test_fixtures"]
 
 [features]
 # Run tests against Karney's GeodTest.dat test cases.


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Supersedes #65  - I prefer the deny-list approach. Though it's less thorough, it seems more self-documenting (we're primarily concerned with excluding the test fixture data) and less likely to surprise me in the future when I forget that I have some non-default crate config.
