### PR TITLE
Exclude development scripts from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/georust/geographiclib-rs"
 keywords = ["gis", "geo", "geography", "geospatial"]
 documentation = "https://docs.rs/geographiclib-rs"
 readme = "README.md"
-exclude = ["test_fixtures"]
+include = ["Cargo.toml", "README.md", "LICENSE", "CHANGES.md", "src/**/*.rs"]
 
 [features]
 # Run tests against Karney's GeodTest.dat test cases.


### PR DESCRIPTION
During a dependency review we noticed that the geographiclib-rs crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from being included in the published packages to make sure that everything that's included is an conscious choice.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

