### PR TITLE
Cleanup atan2d - small perf win... maybe?

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@
   In practice this was already hardcoded in some places, so there was no benefit to having it a configurable parameter.
   Direct bench: -4.4823%
   Inverse bench: -15.856%
+  * See https://github.com/georust/geographiclib-rs/pull/70
+* Speed up Direct/Inverse methods a little by simplifying atan2d
+  Direct bench: -2.8%
+  Inverse bench: -2.5%
+  * See https://github.com/georust/geographiclib-rs/pull/71
+
 
 ## 0.2.6 - 2026-02-06
 

--- a/src/geomath.rs
+++ b/src/geomath.rs
@@ -140,27 +140,31 @@ pub fn sincosd(x: f64) -> (f64, f64) {
 }
 
 // Compute atan2(y, x) with result in degrees
-pub fn atan2d(y: f64, x: f64) -> f64 {
-    let mut x = x;
-    let mut y = y;
+pub fn atan2d(mut y: f64, mut x: f64) -> f64 {
     let mut q = if y.abs() > x.abs() {
         std::mem::swap(&mut x, &mut y);
-        2.0
+        2
     } else {
-        0.0
+        0
     };
     if x < 0.0 {
-        q += 1.0;
+        q += 1;
         x = -x;
     }
     let mut ang = y.atan2(x).to_degrees();
-    if q == 1.0 {
-        ang = if y >= 0.0 { 180.0 - ang } else { -180.0 - ang };
-    } else if q == 2.0 {
-        ang = 90.0 - ang;
-    } else if q == 3.0 {
-        ang += -90.0;
-    }
+    match q {
+        0 => {}
+        1 => {
+            ang = if y >= 0.0 { 180.0 - ang } else { -180.0 - ang };
+        }
+        2 => {
+            ang = 90.0 - ang;
+        }
+        3 => {
+            ang += -90.0;
+        }
+        _ => unreachable!(),
+    };
     ang
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I've run the benches a few times and see between 0 and modest improvements. It certainly doesn't seem to hurt anything and is a little cleaner.
  
    $ cargo bench --bench="*" -- --baseline=main
        Finished `bench` profile [optimized] target(s) in 0.03s
         Running benches/geodesic_benchmark.rs (target/release/deps/geodesic_benchmark-0c8daaebc8aa0a41)
    direct (c wrapper)/default
                            time:   [23.641 µs 23.748 µs 23.866 µs]
                            change: [-0.3721% -0.0680% +0.2433%] (p = 0.66 > 0.05)
                            No change in performance detected.
    Found 12 outliers among 100 measurements (12.00%)
      7 (7.00%) high mild
      5 (5.00%) high severe
    
    direct (rust impl)/default
                            time:   [23.909 µs 23.942 µs 23.979 µs]
                            change: [-3.2611% -2.8830% -2.5052%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 9 outliers among 100 measurements (9.00%)
      6 (6.00%) high mild
      3 (3.00%) high severe
    
    inverse (c wrapper)/default
                            time:   [42.826 µs 42.869 µs 42.918 µs]
                            change: [-0.8657% -0.6826% -0.4995%] (p = 0.00 < 0.05)
                            Change within noise threshold.
    Found 6 outliers among 100 measurements (6.00%)
      6 (6.00%) high mild
    
    inverse (rust impl)/default
                            time:   [54.385 µs 54.443 µs 54.505 µs]
                            change: [-2.7415% -2.5836% -2.4260%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 2 outliers among 100 measurements (2.00%)
      2 (2.00%) high mild