### PR TITLE
return result rather than panic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+* BREAKING: `PolygonArea::add_edge` and `test_edge` now return `Result` instead of panicking when no points have been added.
+
+## v0.2.7 - 2026-02-17
+
 This release is mostly around performance improvements.
 
 Overall changes in benchmark performance since v0.2.6:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,5 +83,6 @@ mod geodesic_line;
 pub use geodesic_line::GeodesicLine;
 mod geomath;
 mod polygon_area;
+pub use polygon_area::AddEdgeError;
 pub use polygon_area::PolygonArea;
 pub use polygon_area::Winding;


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

